### PR TITLE
Improve performance of gettimeofday

### DIFF
--- a/turbo/util.lua
+++ b/turbo/util.lua
@@ -131,8 +131,8 @@ end
 -- @return Number
 function util.gettimeofday()
     C.gettimeofday(g_timeval, nil)
-    return ((tonumber(timeval.tv_sec) * 1000) + 
-        math.floor(tonumber(timeval.tv_usec) / 1000))
+    return ((tonumber(g_timeval.tv_sec) * 1000) + 
+        math.floor(tonumber(g_timeval.tv_usec) / 1000))
 end
 
 --- Create a time string used in HTTP cookies.


### PR DESCRIPTION
Applied fixes to gettimeofday based on knowledge in this thread:
    http://www.freelists.org/post/luajit/simple-change-causes-trace-aborts,1
- Lifted the timeval allocation to a local.
- Put parentheses around the return value calculation
- Replaced occurrences of ffi.C with local 'C'.

In particular, the lack of parentheses around the return value calculation could cause traces to abort, which hurts performance beyond just that function.
