### PR TITLE
Return proper error message when setting SO_REUSEADDR fails

### DIFF
--- a/turbo/socket_ffi.lua
+++ b/turbo/socket_ffi.lua
@@ -255,7 +255,8 @@ local function set_reuseaddr_opt(fd)
         setopt,
         ffi.sizeof("int32_t"))
     if rc ~= 0 then
-       return -1
+       errno = ffi.errno()
+       return -1, string.format("setsockopt SO_REUSEADDR failed. %s", strerror(errno))
     end
     return 0
 end


### PR DESCRIPTION
Found this error when trying to get turbo working on mac os x.
