### PR TITLE
support glob pattern matching for turbovisor file matching

### DIFF
--- a/turbo/cdef.lua
+++ b/turbo/cdef.lua
@@ -515,3 +515,20 @@ elseif ffi.arch == 'x64' then
       };
     ]]
 end
+
+--- ******* glob *******
+ffi.cdef[[
+typedef struct {
+    long unsigned int gl_pathc;
+    char **gl_pathv;
+    long unsigned int gl_offs;
+    int gl_flags;
+    void (*gl_closedir)(void *);
+    void *(*gl_readdir)(void *);
+    void *(*gl_opendir)(const char *);
+    int (*gl_lstat)(const char *restrict, void *restrict);
+    int (*gl_stat)(const char *restrict, void *restrict);
+} glob_t;
+int glob(const char *pattern, int flag, int (*)(const char *, int), glob_t *pglob);
+void globfree(glob_t *pglob);
+]]

--- a/turbo/fs.lua
+++ b/turbo/fs.lua
@@ -55,4 +55,23 @@ function fs.is_dir(path)
     end
 end
 
+function fs.glob(pattern)
+    local re = -1
+    glob_t = ffi.new("glob_t[1]")
+    re = ffi.C.glob(pattern, 0, nil, glob_t)
+    if re ~= 0 then
+        ffi.C.globfree(glob_t)
+        return nil
+    end
+
+    local files = {}
+    local i = 0
+    while i < glob_t[0].gl_pathc do
+        table.insert(files, ffi.string(glob_t[0].gl_pathv[i]))
+        i = i + 1
+    end
+    ffi.C.globfree(glob_t)
+    return files
+end
+
 return fs

--- a/turbovisor.lua
+++ b/turbovisor.lua
@@ -17,6 +17,7 @@
 local ffi = require "ffi"
 local bit = require "bit"
 local turbo = require "turbo"
+local fs = require "turbo.fs"
 
 --- Parsing arguments for turbovisor
 -- @param arg All command line input. Note arg[0] is 'turbovisor', arg[1] is
@@ -38,7 +39,13 @@ local function get_param(arg)
             if string.sub(arg[i], 1, 2) == "./" then
                 arg[i] = string.sub(arg[i], 3) -- pass './'
             end
-            table.insert(arg_tbl[arg_opt], arg[i])
+            local files = fs.glob(arg[i])
+            -- insert glob expanded result into table
+            if files then
+                for _,v in ipairs(files) do
+                    table.insert(arg_tbl[arg_opt], v)
+                end
+            end
         end
     end
     -- Deal with default parameters


### PR DESCRIPTION
this is not that useful for command line arguments since we can use shell to expand the file names as well. But it will be become a needed feature when we add config file (like Grunt has) support in the future, i.e. specify watch file list in a lua file.
