### PR TITLE
Decouple IOLoop scheduler from util.gettimeofday()

### DIFF
--- a/turbo/async.lua
+++ b/turbo/async.lua
@@ -178,7 +178,7 @@ function async.HTTPClient:fetch(url, kwargs)
     self.coctx = coctx.CoroutineContext:new(self.io_loop)
     self.coctx:set_state(coctx.states.WORKING)
     self.in_progress = true
-    self.start_time = util.gettimeofday()
+    self.start_time = util.gettimemonotonic()
     self.kwargs = kwargs or {}
     -- Set sane defaults for kwargs if not present.
     self.redirect_max = self.kwargs.max_redirects or 4
@@ -324,7 +324,7 @@ function async.HTTPClient:_connect()
     end
     -- Add connect timeout.
     self.connect_timeout_ref = self.io_loop:add_timeout(
-        self.kwargs.connect_timeout * 1000 + util.gettimeofday(), 
+        self.kwargs.connect_timeout * 1000 + util.gettimemonotonic(),
         self._handle_connect_timeout,
         self)
     return 0
@@ -434,7 +434,7 @@ function async.HTTPClient:_handle_connect()
     self.io_loop:remove_timeout(self.connect_timeout_ref)
     self.connect_timeout_ref = nil
     self.request_timeout_ref = self.io_loop:add_timeout(
-        self.kwargs.request_timeout * 1000 + util.gettimeofday(), 
+        self.kwargs.request_timeout * 1000 + util.gettimemonotonic(),
         self._handle_request_timeout,
         self)
     self:_send_http_request()
@@ -574,8 +574,8 @@ function async.HTTPClient:_finalize_request()
     if self.connect_timeout_ref then
         self.io_loop:remove_timeout(self.connect_timeout_ref)
     end
-    if not self.s_error then 
-        self.finish_time = util.gettimeofday()
+    if not self.s_error then
+        self.finish_time = util.gettimemonotonic()
         local status_code = self.response_headers:get_status_code()
         if (status_code == 200) then
             log.success(string.format("[async.lua] %s %s%s => %d %s %dms",

--- a/turbo/cdef.lua
+++ b/turbo/cdef.lua
@@ -357,6 +357,20 @@ extern int gettimeofday (struct timeval *tv, timezone_ptr_t tz);
 
 ]])
 
+--- ******* RealTime (for Monotonic time) *******
+ffi.cdef([[
+struct timespec
+{
+    time_t tv_sec;      /* Seconds.  */
+    long tv_nsec;    /* Nanoseconds.  */
+};
+typedef uint32_t clockid_t;
+enum clock_ids {
+    CLOCK_REALTIME,
+    CLOCK_MONOTONIC
+};
+int clock_gettime(clockid_t clk_id, struct timespec *tp);
+]])
 
 --- ******* Resolv *******
 ffi.cdef [[

--- a/turbo/httpserver.lua
+++ b/turbo/httpserver.lua
@@ -368,7 +368,7 @@ function httpserver.HTTPRequest:initialize(method, uri, args)
     self.host = host or self.headers:get("Host") or "127.0.0.1"
     self.files = files or {}
     self.connection = connection
-    self._start_time = util.gettimeofday()
+    self._start_time = util.gettimemonotonic()
     self._finish_time = nil
     self.path = self.headers:get_url_field(httputil.UF.PATH)
     self.arguments = self.headers:get_arguments()
@@ -414,7 +414,7 @@ end
 --- Finish the request. Close connection.
 function httpserver.HTTPRequest:finish()
     self.connection:finish()
-    self._finish_time = util.gettimeofday()
+    self._finish_time = util.gettimemonotonic()
 end
 
 --- Return the full URL that the user requested.
@@ -428,7 +428,7 @@ end
 -- completed.
 function httpserver.HTTPRequest:request_time()
     if not self._finish_time then
-        return util.gettimeofday() - self._start_time
+        return util.gettimemonotonic() - self._start_time
     else
         return self._finish_time - self._start_time
     end

--- a/turbo/ioloop.lua
+++ b/turbo/ioloop.lua
@@ -181,8 +181,8 @@ end
 
 --- Add a timeout with function to be called in future.
 -- @param timestamp (Number) Timestamp when to call function. Based on
--- Unix epoch time in milliseconds precision.
--- E.g util.gettimeofday + 3000 will timeout in 3 seconds.
+-- Unix CLOCK_MONOTONIC time in milliseconds precision.
+-- E.g util.gettimemonotonic + 3000 will timeout in 3 seconds.
 -- @param func (Function)
 -- @param Optional argument for func.
 -- @return (Number) Reference to timeout.
@@ -274,7 +274,7 @@ function ioloop.IOLoop:start()
         end
         local timeout_sz = #self._timeouts
         if timeout_sz ~= 0 then
-            local current_time = util.gettimeofday()
+            local current_time = util.gettimemonotonic()
             for i = 1, timeout_sz do
                 if self._timeouts[i] ~= nil then
                     local time_until_timeout = self._timeouts[i]:timed_out(current_time)
@@ -298,7 +298,7 @@ function ioloop.IOLoop:start()
         end
         local intervals_sz = #self._intervals
         if intervals_sz ~= 0 then
-            local time_now = util.gettimeofday()
+            local time_now = util.gettimemonotonic()
             for i = 1, intervals_sz do
                 if self._intervals[i] ~= nil then
                     local timed_out = self._intervals[i]:timed_out(time_now)
@@ -310,7 +310,7 @@ function ioloop.IOLoop:start()
                         -- Get current time to protect against building
                         -- diminishing interval time on heavy functions.
                         -- It is debatable wether this feature is wanted or not.
-                        time_now = util.gettimeofday()
+                        time_now = util.gettimemonotonic()
                         local next_call = self._intervals[i]:set_last_call(
                             time_now)
                         if next_call < poll_timeout then
@@ -370,7 +370,7 @@ function ioloop.IOLoop:wait(timeout)
     local timedout
     if timeout then
         local io = self
-        self:add_timeout(util.gettimeofday() + (timeout*1000), function()
+        self:add_timeout(util.gettimemonotonic() + (timeout*1000), function()
             timedout = true
             io:close()
         end)
@@ -482,7 +482,7 @@ function _Interval:initialize(msec, callback, arg)
     self.interval_msec = msec
     self.callback = callback
     self.arg = arg
-    self.next_call = util.gettimeofday() + self.interval_msec
+    self.next_call = util.gettimemonotonic() + self.interval_msec
 end
 
 function _Interval:timed_out(time_now)

--- a/turbo/util.lua
+++ b/turbo/util.lua
@@ -136,6 +136,19 @@ function util.gettimeofday()
         math.floor(tonumber(g_timeval.tv_usec) / 1000))
 end
 
+do
+    local rt = ffi.load("rt")
+    local ts = ffi.new("struct timespec")
+    -- Current msecs since arbitrary start point, doesn't jump due to
+    -- time changes
+    -- @return Number
+    function util.gettimemonotonic()
+        rt.clock_gettime(rt.CLOCK_MONOTONIC, ts)
+        return ((tonumber(ts.tv_sec)*1000) +
+                math.floor(tonumber(ts.tv_nsec) / 1000000))
+    end
+end
+
 --- Create a time string used in HTTP cookies.
 -- "Sun, 04-Sep-2033 16:49:21 GMT"
 function util.time_format_cookie(epoch)


### PR DESCRIPTION
Use clock_gettime() from the rt library with clock_id_t
of CLOCK_MONOTONIC in order for timeouts in the scheduler
to work correctly when the system time is changed.
