### PR TITLE
couple of docfixes

### DIFF
--- a/doc/async.rst
+++ b/doc/async.rst
@@ -1,7 +1,7 @@
 .. _async:
 
 ***********************************
-turbo.async -- Asynchronous clients 
+turbo.async -- Asynchronous clients
 ***********************************
 
 Utilities for coroutines
@@ -9,7 +9,7 @@ Utilities for coroutines
 
 .. function:: task(func, ...)
 
-	A wrapper for functions that always takes callback and callback 
+	A wrapper for functions that always takes callback and callback
 	argument as last arguments to be able to yield and resume execution of
 	function when callback is called from another function.
 
@@ -17,7 +17,7 @@ Utilities for coroutines
 	call the callback is put in the left-side result.
 
 	Usage:
-	Consider one of the functions of the IOStream class which uses a 
+	Consider one of the functions of the IOStream class which uses a
 	callback based API: IOStream:read_until(delimiter, callback, arg)
 
 .. code-block:: lua
@@ -25,23 +25,23 @@ Utilities for coroutines
 
 	local res = coroutine.yield(turbo.async.task(
 		stream.read_until, stream, "\r\n"))
-		
+
 	-- Result from read_until operation will be returned in the res variable.
 
 
 HTTPClient class
 ~~~~~~~~~~~~~~~~
 Based on the IOStream/SSLIOStream and IOLoop classes.
-Designed to asynchronously communicate with a HTTP server via the Turbo I/O 
-Loop. The user MUST use Lua's builtin coroutines to manage yielding, after 
-doing a request. The aim for the client is to support as many standards of 
-HTTP as possible. However there may be some artifacts as there usually are 
+Designed to asynchronously communicate with a HTTP server via the Turbo I/O
+Loop. The user MUST use Lua's builtin coroutines to manage yielding, after
+doing a request. The aim for the client is to support as many standards of
+HTTP as possible. However there may be some artifacts as there usually are
 many compability fixes in equivalent software such as curl.
-Websockets are not handled by this class. It is the users responsibility to 
+Websockets are not handled by this class. It is the users responsibility to
 check the returned values for errors before usage.
 
-When using this class, keep in mind that it is not supported to launch 
-muliple :fetch()'s with the same class instance. If the instance is already 
+When using this class, keep in mind that it is not supported to launch
+muliple :fetch()'s with the same class instance. If the instance is already
 in use then it will return a error.
 
 Usage inside a ``turbo.web.RequestHandler`` method:
@@ -52,13 +52,13 @@ Usage inside a ``turbo.web.RequestHandler`` method:
 	local res = coroutine.yield(
 	   	turbo.async.HTTPClient():fetch("http://domain.com/latest"))
 	if res.error then
-		self.write("Could not get latest from domain.come")
+		self:write("Could not get latest from domain.come")
 	else
-		self.write(res.body)
+		self:write(res.body)
 	end
 
 .. function:: HTTPClient(ssl_options, io_loop, max_buffer_size)
-	
+
 	Create a new HTTPClient class instance. One instance can serve 1 request
 	at a time. If multiple request should be sent then create multiple instances.
 
@@ -71,15 +71,15 @@ Usage inside a ``turbo.web.RequestHandler`` method:
 
 	Available SSL options:
 
-	* "priv_file" (String) - Path to SSL / HTTPS private key file.              
-	* "cert_file" (String) - Path to SSL / HTTPS certificate key file.          
-	* "ca_path" (String) - Path to SSL / HTTPS CA certificate verify location, if not given builtin is used, which is copied from Ubuntu 12.10. 
+	* "priv_file" (String) - Path to SSL / HTTPS private key file.
+	* "cert_file" (String) - Path to SSL / HTTPS certificate key file.
+	* "ca_path" (String) - Path to SSL / HTTPS CA certificate verify location, if not given builtin is used, which is copied from Ubuntu 12.10.
 	* "verify_ca" (Boolean) SSL / HTTPS verify servers certificate. Default is true.
 
-.. attribute::	errors 
+.. attribute::	errors
 
 	Numeric error codes set in the HTTPResponse returned by ``HTTPClient:fetch``:
-    
+
 	    INVALID_URL            - URL could not be parsed.
 
 	    INVALID_SCHEMA         - Invalid URL schema

--- a/doc/web.rst
+++ b/doc/web.rst
@@ -5,14 +5,14 @@ turbo.web -- Core web framework
 *******************************
 
 The Turbo.lua Web framework is modeled after the framework offered by
-Tornado (http://www.tornadoweb.org/), which again is based on web.py (http://webpy.org/) and 
+Tornado (http://www.tornadoweb.org/), which again is based on web.py (http://webpy.org/) and
 Google's webapp (http://code.google.com/appengine/docs/python/tools/webapp/)
 Some modifications has been made to make it fit better into the Lua
 eco system. The web framework utilizes asynchronous features that allow it
 to scale to large numbers of open connections (thousands). The framework support
 comet polling.
 
-Create a web server that listens to port 8888 and prints the canoncial Hello world on 
+Create a web server that listens to port 8888 and prints the canoncial Hello world on
 a GET request is very easy:
 
 .. code-block:: lua
@@ -21,11 +21,11 @@ a GET request is very easy:
 	local turbo = require('turbo')
 
 	local ExampleHandler = class("ExampleHandler", turbo.web.RequestHandler)
-	function ExampleHandler:get() 
-		self:write("Hello world!") 
+	function ExampleHandler:get()
+		self:write("Hello world!")
 	end
 
-	local application = turbo.web.Application({ 
+	local application = turbo.web.Application({
 		{"^/$", ExampleHandler}
 	})
 	application:listen(8888)
@@ -36,9 +36,9 @@ RequestHandler class
 ~~~~~~~~~~~~~~~~~~~~
 Base RequestHandler class. The heart of Turbo.lua.
 The usual flow of using Turbo.lua is sub-classing the RequestHandler
-class and implementing the HTTP request methods described in 
+class and implementing the HTTP request methods described in
 self.SUPPORTED_METHODS. The main goal of this class is to wrap a HTTP
-request and offer utilities to respond to the request. Requests are 
+request and offer utilities to respond to the request. Requests are
 deligated to RequestHandler's by the Application class.
 The RequestHandler class are implemented so that it should be subclassed to process HTTP requests.
 
@@ -49,12 +49,12 @@ Entry points
 
 .. function:: RequestHandler:on_create(kwargs)
 
-	Redefine this method if you want to do something straight after the class 
-	has been initialized. This is called after a request has been 
+	Redefine this method if you want to do something straight after the class
+	has been initialized. This is called after a request has been
 	recieved, and before the HTTP method has been verified against supported
-	methods. So if a not supported method is requested, this method is still 
+	methods. So if a not supported method is requested, this method is still
 	called.
-        
+
         :param kwargs: The keyword arguments that you initialize the class with.
         :type kwargs: Table
 
@@ -70,8 +70,8 @@ Entry points
 
 .. function:: RequestHandler:set_default_headers()
 
-	Redefine this method to set HTTP headers at the beginning of all the 
-	request recieved by the RequestHandler. For example setting some kind 
+	Redefine this method to set HTTP headers at the beginning of all the
+	request recieved by the RequestHandler. For example setting some kind
 	of cookie or adjusting the Server key in the headers would be sensible
 	to do in this method.
 
@@ -81,45 +81,45 @@ If not implemented they will provide a 405 (Method Not Allowed).
 These methods recieve variable arguments, depending on what the Application
 instance calling them has captured from the pattern matching of the request
 URL. The methods are run protected, so they are error safe. When a error
-occurs in the execution of these methods the request is given a 
+occurs in the execution of these methods the request is given a
 500 Internal Server Error response. In debug mode, the stack trace leading
 to the crash is also a part of the response. If not debug mode is set, then
 only the status code is set.*
 
-.. function:: RequestHandler:get(...)	
-	
+.. function:: RequestHandler:get(...)
+
 	HTTP GET reqests handler.
-        
+
         :param ...: Parameters from matched URL pattern with braces. E.g /users/(.*)$ would provide anything after /users/ as first parameter.
 
 .. function:: RequestHandler:post(...)
 
 	HTTP POST reqests handler.
-        
+
         :param ...: Parameters from matched URL pattern with braces.
 
 .. function:: RequestHandler:head(...)
 
 	HTTP HEAD reqests handler.
-        
+
         :param ...: Parameters from matched URL pattern with braces.
 
 .. function:: RequestHandler:delete(...)
 
 	HTTP DELETE reqests handler.
-        
+
         :param ...: Parameters from matched URL pattern with braces.
 
 .. function:: RequestHandler:put(...)
 
 	HTTP PUT reqests handler.
-        
+
         :param ...: Parameters from matched URL pattern with braces.
 
 .. function:: RequestHandler:options(...)
 
 	HTTP OPTIONS reqests handler.
-        
+
         :param ...: Parameters from matched URL pattern with braces.
 
 Input
@@ -128,8 +128,8 @@ Input
 .. function:: RequestHandler:get_argument(name, default, strip)
 
 	Returns the value of the argument with the given name.
-	If default value is not given the argument is considered to be required and 
-	will result in a raise of a HTTPError 400 Bad Request if the argument does 
+	If default value is not given the argument is considered to be required and
+	will result in a raise of a HTTPError 400 Bad Request if the argument does
 	not exist.
 
 	:param name: Name of the argument to get.
@@ -138,12 +138,12 @@ Input
 	:type default: String
 	:param strip: Remove whitespace from head and tail of string.
 	:type strip: Boolean
-	:rtype: String 
+	:rtype: String
 
 .. function:: RequestHandler:get_arguments(name, strip)
 
 	Returns the values of the argument with the given name. Should be used when you expect multiple arguments values with same name. Strip will take away whitespaces at head and tail where 		applicable. Returns a empty table if argument does not exist.
-	
+
 	:param name: Name of the argument to get.
 	:type name: String
 	:param strip: Remove whitespace from head and tail of string.
@@ -164,12 +164,12 @@ Input
 
 	Get a signed cookie value from incoming request.
 
-	If the cookie can not be validated, then an error with a string error 
+	If the cookie can not be validated, then an error with a string error
 	is raised.
-	
+
 	Hash-based message authentication code (HMAC) is used to be able to verify
-	that the cookie has been created with the "cookie_secret" set in the 
-	Application class kwargs. This is simply verifing that the cookie has been 
+	that the cookie has been created with the "cookie_secret" set in the
+	Application class kwargs. This is simply verifing that the cookie has been
 	signed by your key, IT IS NOT ENCRYPTING DATA.
 
 	:param name: The name of the cookie to get.
@@ -182,8 +182,8 @@ Input
 
 .. function :: RequestHandler:set_cookie(name, value, domain, expire_hours)
 
-	Set a cookie with value to response. 
-	
+	Set a cookie with value to response.
+
 	Note: Expiring relies on the requesting browser and may or may not be respected. Also keep in mind that the servers time is used to calculate expiry date, so the server should ideally be set up with NTP server.
 
 	:param name: The name of the cookie to set.
@@ -200,10 +200,10 @@ Input
 	Set a signed cookie value to response.
 
 	Hash-based message authentication code (HMAC) is used to be able to verify
-	that the cookie has been created with the "cookie_secret" set in the 
-	Application class kwargs. This is simply verifing that the cookie has been 
-	signed by your key, IT IS NOT ENCRYPTING DATA. 
-	
+	that the cookie has been created with the "cookie_secret" set in the
+	Application class kwargs. This is simply verifing that the cookie has been
+	signed by your key, IT IS NOT ENCRYPTING DATA.
+
 	Note: Expiring relies on the requesting browser and may or may not be respected. Also keep in mind that the servers time is used to calculate expiry date, so the server should ideally be set up with NTP server.
 
 	:param name: The name of the cookie to set.
@@ -213,7 +213,7 @@ Input
 	:param domain: The domain to apply cookie for.
 	:type domain: String
 	:param expire_hours: Set cookie to expire in given amount of hours.
-	:type expire_hours: Number	
+	:type expire_hours: Number
 
 :RequestHandler.request:
 
@@ -224,11 +224,11 @@ Output
 
 .. function:: RequestHandler:write(chunk)
 
-	Writes the given chunk to the output buffer.			
+	Writes the given chunk to the output buffer.
 	To write the output to the network, call the ``turbo.web.RequestHandler:flush()`` method.
 	If the given chunk is a Lua table, it will be automatically
 	stringifed to JSON.
-        
+
         :param chunk: Data chunk to write to underlying connection.
         :type chunk: String
 
@@ -236,32 +236,32 @@ Output
 
 	Finishes the HTTP request. This method can only be called once for each
 	request. This method flushes all data in the write buffer.
-        
+
         :param chunk: Final data to write to stream before finishing.
         :type chunk: String
 
 .. function:: RequestHandler:flush(callback)
 
 	Flushes the current output buffer to the IO stream.
-			
-	If callback is given it will be run when the buffer has 
+
+	If callback is given it will be run when the buffer has
 	been written to the socket. Note that only one callback flush
 	callback can be present per request. Giving a new callback
 	before the pending has been run leads to discarding of the
-	current pending callback. For HEAD method request the chunk 
+	current pending callback. For HEAD method request the chunk
 	is ignored and only headers are written to the socket.
-        
+
         :param callback: Function to call after the buffer has been flushed.
         :type callback: Function
 
 .. function:: RequestHandler:clear()
-	
+
 	Reset all headers, empty write buffer in a request.
 
 .. function:: RequestHandler:add_header(name, value)
 
 	Add the given name and value pair to the HTTP response headers.
-        
+
         :param name: Key string for header field.
         :type name: String
         :param value: Value for header field.
@@ -270,37 +270,37 @@ Output
 .. function:: RequestHandler:set_header(name, value)
 
 	Set the given name and value pair of the HTTP response headers. If name exists then the value is overwritten.
-        
+
         :param name: Key string for header field.
         :type name: String
         :param value: Value for header field.
         :type value: String
-        
+
 .. function:: RequestHandler:get_header(name)
 
 	Returns the current value of the given name in the HTTP response headers. Returns nil if not set.
-        
+
         :param name: Name of value to get.
         :type name: String
         :rtype: String or nil
 
 .. function:: RequestHandler:set_status(code)
-	
+
 	Set the status code of the HTTP response headers. Must be number or error is raised.
-	
+
 	:param code: HTTP status code to set.
 	:type code: Number
 
 .. function:: RequestHandler:get_status()
-	
+
 	Get the curent status code of the HTTP response headers.
-	
+
 	:rtype: Number
 
 .. function:: RequestHandler:redirect(url, permanent)
 
 	Redirect client to another URL. Sets headers and finish request. User can not send data after this.
-        
+
 	:param url: The URL to redirect to.
 	:type url: String
 	:param permanent: Flag this as a permanent redirect or temporary.
@@ -320,7 +320,7 @@ Misc
 
 HTTPError class
 ~~~~~~~~~~~~~~~
-This error is raisable from RequestHandler instances. It provides a 
+This error is raisable from RequestHandler instances. It provides a
 convinent and safe way to handle errors in handlers. E.g it is allowed to
 do this:
 
@@ -328,7 +328,7 @@ do this:
    :linenos:
 
 	function MyHandler:get()
-	    local item = self.get_argument("item")
+	    local item = self:get_argument("item")
 	     if not find_in_store(item) then
 	         error(turbo.web.HTTPError(400, "Could not find item in store"))
 	     end
@@ -336,12 +336,12 @@ do this:
 	end
 
 The result is that the status code is set to 400 and the message is sent as
-the body of the request. The request is always finished on error. 
+the body of the request. The request is always finished on error.
 
 .. function:: HTTPError(code, message)
-	
+
 	Create a new HTTPError class instance.
-	
+
 	:param code: The HTTP status code to send to send to client.
 	:type code: Number
 	:param message: Optional message to pass as body in the response.
@@ -350,9 +350,9 @@ the body of the request. The request is always finished on error.
 
 StaticFileHandler class
 ~~~~~~~~~~~~~~~~~~~~~~~
-A simple static file handler. All files are cached in memory after initial request. 
+A simple static file handler. All files are cached in memory after initial request.
 If you are planning to serve big files, then it is recommended to use a
-proper static file web server instead. For small files that can be kept 
+proper static file web server instead. For small files that can be kept
 in memory it is ok.
 
 Usage:
@@ -385,8 +385,8 @@ The Application class is a collection of request handler classes that make toget
 
 .. code-block:: lua
    :linenos:
-	
-	local application = turbo.web.Application({ 
+
+	local application = turbo.web.Application({
 		{"^/static/(.*)$", turbo.web.StaticFileHandler, "/var/www/"},
 		{"^/$", ExampleHandler},
 		{"^/item/(%d*)", ItemHandler}
@@ -400,21 +400,21 @@ The first element in the table is the URL that the application class matches inc
 The ItemHandler URL pattern is an example on how to map numbers from URL to your handlers. Pattern encased in parantheses are used as parameters when calling the request methods in your handlers.
 
 *Note: Patterns are matched in a sequential manner. If a request matches multiple
-handler pattern's only the first handler matched is delegated the request. Therefore, it is important to write good patterns.* 
+handler pattern's only the first handler matched is delegated the request. Therefore, it is important to write good patterns.*
 
 A good read on Lua patterns matching can be found here: http://www.wowwiki.com/Pattern_matching.
 
 .. function:: Application(handlers, kwargs)
 
 	Initialize a new Application class instance.
-	
+
 	:param handlers: As described above. Table of tables with pattern to handler binding.
 	:type handlers: Table
 	:param kwargs: Keyword arguments
 	:type kwargs: Table
 
 	Keyword arguments supported:
-	
+
 	* "default_host" (String) - Redirect to this URL if no matching handler is found.
 	* "cookie_secret" (String) - Sequence of bytes used for to sign cookies.
 
@@ -424,17 +424,17 @@ A good read on Lua patterns matching can be found here: http://www.wowwiki.com/P
 
 	:param pattern: Lua pattern string.
 	:type pattern: String
-	:param handler: 
+	:param handler:
 	:type handler: RequestHandler based class
 	:param arg: Argument for handler.
 
 .. function:: Application:listen(port, address, kwargs)
-	
+
 	Starts an HTTP server for this application on the given port.
 	This is really just a convinence method. The same effect can be achieved
-	by creating a ``turbo.httpserver.HTTPServer`` class instance and assigning the Application instance to its request_callback parameter and calling its listen() 
+	by creating a ``turbo.httpserver.HTTPServer`` class instance and assigning the Application instance to its request_callback parameter and calling its listen()
 	method.
-	 
+
 	:param port: TCP port to bind server to.
 	:type port: Number
 	:param address: Optional address to bind server to. Use ``turbo.socket.htonl()`` to create address. We use the unsigned integer hostlong format of the IP.
@@ -452,7 +452,7 @@ A good read on Lua patterns matching can be found here: http://www.wowwiki.com/P
 .. function:: Application:set_server_name(name)
 
 	Sets the name of the server. Used in the response headers.
-	
+
 	:param name: The name used in HTTP responses. Default is "Turbo vx.x"
 	:type name: String
 
@@ -460,8 +460,8 @@ A good read on Lua patterns matching can be found here: http://www.wowwiki.com/P
 
 	Gets the current name of the server.
 	:rtype: String
-	
-        
+
+
 Mustache Templating
 ~~~~~~~~~~~~~~~~~~~
 
@@ -474,19 +474,19 @@ For more information on the Mustache markup, please see this:
 http://mustache.github.io/mustache.5.html
 
 .. function:: Mustache.compile(template)
-    
+
     Compile a Mustache highlighted string into its intermediate state before rendering. This function does some validation on the template. If it finds
     syntax errors a error with a message is raised. It is always a good idea to cache pre-compiled frequently used templates before rendering them. Although
     compiling each time is usally not a big overhead. This function can throw errors if the template contains invalid logic.
-    
+
     :param template: (String) Template in string form.
     :rtype: Parse table that can be used for Mustache.render function
-    
+
 .. function:: Mustache.render(template, obj, partials, allow_blank)
 
     Render a template. Accepts a parse table compiled by Mustache.compile or a uncompiled string. Obj is the table with keys. This function can throw errors in
     case of un-compiled string being compiled with Mustache.compile internally.
-    
+
     :param template: Accepts a pre-compiled template or a un-compiled string.
     :param obj: Parameters for template rendering.
     :type obj: Table
@@ -498,15 +498,15 @@ Example templating:
 
 .. code-block:: html
    :linenos:
-   
+
     <body>
         <h1>
                 {{heading }}
         </h1>
-        {{! 	
-            Some comment section that 
+        {{!
+            Some comment section that
             even spans across multiple lines,
-            that I just have to have to explain my flawless code.		
+            that I just have to have to explain my flawless code.
         }}
         <h2>
             {{{desc}}} {{! No escape with triple mustaches allow HTML tags! }}
@@ -520,7 +520,7 @@ Example templating:
                     Type available: {{type}}
             {{/types}}
             {{^types}}	Only one type available.
-            {{! Apparently only one type is available because types is not set, 
+            {{! Apparently only one type is available because types is not set,
             determined by the hat char ^}}
             {{/types}}
         {{/items}}
@@ -528,19 +528,19 @@ Example templating:
                 No items available!
         {{/items}}
     </body>
-    
+
 With a render table likes this:
-    
+
 .. code-block:: lua
-    
+
     {
-        heading="My website!", 
+        heading="My website!",
         desc="<b>Big important website</b>",
         age=27,
         items={
-                  {item="Bread", 
+                  {item="Bread",
                       types={
-                          {type="light"}, 
+                          {type="light"},
                           {type="fatty"}
                       }
               },
@@ -548,7 +548,7 @@ With a render table likes this:
               {item="Sugar"}
        }
     }
-    
+
 Will produce this output after rendering:
 
 .. code-block:: html
@@ -558,19 +558,19 @@ Will produce this output after rendering:
             My%20website%21
         </h1>
         <h2>
-            <b>Big important website</b> 
-            <b>Big important website</b> 
+            <b>Big important website</b>
+            <b>Big important website</b>
         </h2>
         <p>I am 27 years old. What would you like to buy in my shop?</p>
             Item: Bread
                 Type available: light
                 Type available: fatty
-            Item: Milk		
+            Item: Milk
                 Only one type available.
             Item: Sugar
                 Only one type available.
     </body>
-    
+
 Mustache.TemplateHelper class
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -583,20 +583,20 @@ A simple class that simplifies the loading of Mustache templates, pre-compile an
     :param base_path: Template base directory. This will be used as base path when loading templates using the load method.
     :type base_path: String
     :rtype: ``Mustache.TemplateHelper class``
-    
+
 .. function:: Mustache.TemplateHelper:load(template)
 
     Pre-load a template.
-    
+
     :param template: Template name, e.g file name in base directory.
     :type template: String
-    
+
 .. function:: Mustache.TemplateHelper:render(template, table, partials, allow_blank)
 
     Render a template by name. If called twice the template will be cached from first time.
 
     :param template: Template name, e.g file name in base directory.
-    :type template: String    
+    :type template: String
     :param obj: Parameters for template rendering.
     :type obj: Table
     :param partials: Partial snippets. Will be treated as static and not compiled...


### PR DESCRIPTION
A couple of typos in the docs are fixed ( self.  vs self:  )

Also, by accident, my editor cleared trailing whitespaces from both files. I don't think it's an issue (I also see it as a cleanup), but if you do, I'll reissue the PR.

You can see the non-whitespace changes here: https://github.com/kernelsauce/turbo/pull/115/files?w=1
