### PR TITLE
Fixed incorrect new construction of SHA1_CTX typedef struct.

### DIFF
--- a/turbo/hash.lua
+++ b/turbo/hash.lua
@@ -51,7 +51,7 @@ if _G.TURBO_AXTLS then
     -- it.
     -- @param str (String)
     function hash.SHA1:initialize(str)
-        local sha1ctx = ffi.new("struct SHA1_CTX")
+        local sha1ctx = ffi.new("SHA1_CTX")
         lssl.SHA1_Init(sha1ctx)
 
         if type(str) == "string" then


### PR DESCRIPTION
The call to ffi.new() for SHA1_CTX shouldn't have had "struct" in front of the name.  I am not sure how this was working when I tested previously.
