### PR TITLE
Further improve speed of mime base64 encoding routines.

### DIFF
--- a/turbo/util.lua
+++ b/turbo/util.lua
@@ -145,8 +145,8 @@ end
 -- @return Number
 function util.gettimeofday()
     C.gettimeofday(g_timeval, nil)
-    return ((tonumber(g_timeval.tv_sec) * 1000) +
-        math.floor(tonumber(g_timeval.tv_usec) / 1000))
+    return (tonumber((g_timeval.tv_sec * 1000)+
+                     (g_timeval.tv_usec / 1000)))
 end
 
 do
@@ -157,8 +157,7 @@ do
     -- @return Number
     function util.gettimemonotonic()
         rt.clock_gettime(rt.CLOCK_MONOTONIC, ts)
-        return ((tonumber(ts.tv_sec)*1000) +
-                math.floor(tonumber(ts.tv_nsec) / 1000000))
+        return (tonumber((ts.tv_sec*1000)+(ts.tv_nsec/1000000)))
     end
 end
 


### PR DESCRIPTION
With these changes Base64 decode is a little faster than libb64 on my 
AMD FX6100, and very slightly slower (a few percent) than libb64 for 
encoding.  The speeds of encoding and decoding are both now 
approximately 4x faster than before these changes.

Also optamize util.gettimeofday() and util.gettimemonotonic().
