### PR TITLE
Add support for Application settings.

### DIFF
--- a/examples/appsettings.lua
+++ b/examples/appsettings.lua
@@ -1,0 +1,31 @@
+--- Turbo.lua Application settings example
+--
+-- Copyright 2013 John Abrahamsen
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+-- http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+local turbo = require "turbo"
+
+local ExampleHandler = class("ExampleHandler", turbo.web.RequestHandler)
+
+function ExampleHandler:get()
+    local name = self:settings().name
+    self:write(string.format("Hello %s!", name))
+end
+
+turbo.web.Application({
+    {"^/$", ExampleHandler}
+}, {
+    name="World"
+}):listen(8888)
+turbo.ioloop.instance():start()

--- a/turbo/web.lua
+++ b/turbo/web.lua
@@ -894,15 +894,18 @@ web.Application = class("Application")
 --- Initialize a new Application class instance.
 -- @param handlers (Table) As described above.
 
--- @param kwargs (Table) Key word arguments.
--- Key word arguments supported:
+-- @param settings (Table) Application settings.
+-- Settings used by the Application:
 -- "default_host" = Redirect to this URL if no matching handler is found.
 -- "cookie_secret" = Sequence of bytes used for to sign cookies.
-function web.Application:initialize(handlers, kwargs)
+-- "application_name" = The name used for the server header.
+-- Other settings are user defined and can be accessed by calling
+-- self:settings() in request handlers.
+function web.Application:initialize(handlers, settings)
     self.handlers = handlers or {}
-    self.kwargs = kwargs or {}
-    self.default_host = self.kwargs.default_host
-    self.application_name = self.kwargs.application_name or "Turbo.lua v1.1"
+    self.settings = settings or {}
+    self.default_host = self.settings.default_host
+    self.application_name = self.settings.application_name or "Turbo.lua v1.1"
 end
 
 --- Sets the server name.


### PR DESCRIPTION
This patch adds support for user defined settings from the keyword arguments to the Application constructor.

I'm guessing this was supposed to be implemented at some point since RequestHandler has a :settings() function that currently only returns nil.

An example file is included to show usage.
