### PR TITLE
fix in websocket.lua

### DIFF
--- a/turbo/websocket.lua
+++ b/turbo/websocket.lua
@@ -209,8 +209,9 @@ if le then
     function websocket.WebSocketStream:_frame_len_16(data)
         -- Network byte order for multi-byte length values.
         -- What were they thinking!
-        self._payload_len = tonumber(
-            ffi.C.htons(ffi.cast("uint16_t", data)))
+        local tmp = ffi.new("uint16_t[1]")
+        ffi.copy(tmp, data, 2)
+        self._payload_len = tonumber(ffi.C.ntohs(tmp[0]))
         if self._mask_bit then
             self.stream:read_bytes(4, self._frame_mask_key, self)
         else


### PR DESCRIPTION
In websocket api, if payload>=126 then payload length is incorrectly computed. 
Stems from the lines 212-213 in websocket.lua: 
in function "_frame_len_16(data)", data is string type so;
ffi.cast("uint16_t", data) casts data's address instead of the value pointed that address.

Have not tested but the same should be true for the following function "_frame_len_64(data)"