### PR TITLE
Fix and improve loading of libtffi helper library

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -114,8 +114,8 @@ install:
 
 test:
 	@echo "==== Running tests for Turbo.lua. NOTICE: busted module is required ===="
-	busted
-	luajit examples/helloworld.lua &
+	export LD_LIBRARY_PATH=$(INSTALL_LIB); busted
+	export LD_LIBRARY_PATH=$(INSTALL_LIB); luajit examples/helloworld.lua &
 	sleep 1
 	wget http://127.0.0.1:8888/
 	test -f index.html

--- a/turbo/crypto_linux.lua
+++ b/turbo/crypto_linux.lua
@@ -18,21 +18,13 @@
 local ffi = require "ffi"
 local platform = require "turbo.platform"
 local socket = require "turbo.socket_ffi"
+local util = require "turbo.util"
 require "turbo.cdef"
 
 local crypto = {} -- crypto namespace
 
 local lssl = ffi.load(os.getenv("TURBO_LIBSSL") or "ssl")
-local libtffi_loaded, libtffi = pcall(
-    ffi.load, os.getenv("TURBO_LIBTFFI") or "tffi_wrap")
-if not libtffi_loaded then
-    libtffi_loaded, libtffi =
-        pcall(ffi.load, "/usr/local/lib/libtffi_wrap.so")
-    if not libtffi_loaded then
-        error("Could not load libtffi_wrap.so. \
-        Please run makefile and ensure that installation is done correct.")
-    end
-end
+local libtffi = util.load_libtffi()
 
 crypto.X509_FILETYPE_PEM =          1
 crypto.X509_FILETYPE_ASN1 =         2

--- a/turbo/httputil.lua
+++ b/turbo/httputil.lua
@@ -33,17 +33,7 @@ local escape =      require "turbo.escape"
 local util =        require "turbo.util"
 local platform =    require "turbo.platform"
 local ffi =         require "ffi"
-local ltp_loaded, libturbo_parser = pcall(
-    ffi.load, os.getenv("TURBO_LIBTFFI") or "tffi_wrap")
-if not ltp_loaded then
-    -- Check /usr/local/lib explicitly also.
-    ltp_loaded, libturbo_parser =
-        pcall(ffi.load, "/usr/local/lib/libtffi_wrap.so")
-    if not ltp_loaded then
-        error("Could not load libtffi_wrap.so. \
-            Please run makefile and ensure that installation is done correct.")
-    end
-end
+local libturbo_parser = util.load_libtffi()
 
 require "turbo.cdef"
 require "turbo.3rdparty.middleclass"

--- a/turbo/util.lua
+++ b/turbo/util.lua
@@ -342,4 +342,16 @@ function util.mem_dump(ptr, sz)
     io.write("\n")
 end
 
+--- Loads dynamic library with helper functions or bails out with error.
+-- @param name Custom library name or path
+function util.load_libtffi(name)
+    name = name or os.getenv("TURBO_LIBTFFI") or "libtffi_wrap"
+    local ok, lib = pcall(ffi.load, name)
+    if not ok then
+        error("Could not load " .. name .. " \
+        Please run makefile and ensure that installation is done correct.")
+    end
+    return lib
+end
+
 return util

--- a/turbo/websocket.lua
+++ b/turbo/websocket.lua
@@ -41,15 +41,7 @@ local web =             require "turbo.web"
 local async =           require "turbo.async"
 local buffer =          require "turbo.structs.buffer"
 require('turbo.3rdparty.middleclass')
-local ltp_loaded, libturbo_parser = pcall(ffi.load, "libtffi_wrap.dll")
-if not ltp_loaded then
-    -- Check /usr/local/lib explicitly also.
-    ltp_loaded, libturbo_parser =
-        pcall(ffi.load, "/usr/local/lib/libtffi_wrap.so")
-    if not ltp_loaded then
-        error("Could not load libtffi_wrap.so.")
-    end
-end
+local libturbo_parser = util.load_libtffi()
 local le = ffi.abi("le")
 local be = not le
 local strf = string.format


### PR DESCRIPTION
* Remove superfluos /usr/local/lib path as it's default libc search patch. If
  necessary one can supply custom search path via LD_LIBRARY_PATH environment
  variable.

* Do not supply library extension as this should be handled in LuaJit already.

Signed-off-by: Petr Štetiar <ynezz@true.cz>