### PR TITLE
Port to PPC64

### DIFF
--- a/turbo/cdef.lua
+++ b/turbo/cdef.lua
@@ -410,6 +410,29 @@ if platform.__LINUX__ then
             unsigned int __unused5;
           };
         ]]
+    elseif platform.__PPC64__ then
+        ffi.cdef [[
+          struct stat {
+            unsigned long   st_dev;
+            unsigned long   st_ino;
+            unsigned long   st_nlink;
+            unsigned int    st_mode;
+            unsigned int    st_uid;
+            unsigned int    st_gid;
+            unsigned int    __pad0;
+            unsigned long   st_rdev;
+            long            st_size;
+            long            st_blksize;
+            long            st_blocks;
+            unsigned long   st_atime;
+            unsigned long   st_atime_nsec;
+            unsigned long   st_mtime;
+            unsigned long   st_mtime_nsec;
+            unsigned long   st_ctime;
+            unsigned long   st_ctime_nsec;
+            long            __unused[3];
+          };
+        ]]
     elseif platform.__ARM__ then
         ffi.cdef[[
           struct stat {

--- a/turbo/cdef.lua
+++ b/turbo/cdef.lua
@@ -272,7 +272,7 @@ if platform.__LINUX__ then
             uint64_t u64;
         } epoll_data_t;
     ]]
-    if platform.__ABI32__ then
+    if platform.__ABI32__ or platform.__PPC64__ then
         ffi.cdef[[
             struct epoll_event{
                 unsigned int events;

--- a/turbo/platform.lua
+++ b/turbo/platform.lua
@@ -31,6 +31,6 @@ return {
     __ABI64__ = ffi.abi("64bit"),
     __X86__ = ffi.arch == "x86",
     __X64__ = ffi.arch == "x64",
-    __PPC_ = ffi.arch == "ppc",
+    __PPC__ = ffi.arch == "ppc",
     __ARM__ = ffi.arch == "arm"
 }

--- a/turbo/platform.lua
+++ b/turbo/platform.lua
@@ -32,5 +32,6 @@ return {
     __X86__ = ffi.arch == "x86",
     __X64__ = ffi.arch == "x64",
     __PPC__ = ffi.arch == "ppc",
+    __PPC64__ = ffi.arch == "ppc64le",
     __ARM__ = ffi.arch == "arm"
 }

--- a/turbo/syscall.lua
+++ b/turbo/syscall.lua
@@ -83,7 +83,7 @@ elseif ffi.arch == "x64" then
         SYS_clock_getres     = 229,
         SYS_clock_nanosleep  = 230
     }
-elseif ffi.arch == "ppc" then
+elseif ffi.arch == "ppc" or ffi.arch == "ppc64le" then
     cmds = {
         SYS_stat             = 106,
         SYS_fstat            = 108,


### PR DESCRIPTION
I just updated Turbolua to be able to run also on POWER architecture 64 bits.

Our team is still finishing the LuaJIT port to PPC64 so it's not on the official repository yet. Take a look at our Wiki hosted on GitHub for the latest status and for our code, if you want to check:
https://github.com/LuaJIT-PPC64/LuaJIT-PPC64/tree/ppc64-port

That LuaJIT is already functional and on Turbolua I was able to run some examples like the chatapp. If you have more tests that we can run on our PPC64 machine in order to find possible bugs, give us a hint please.