### PR TITLE
Create missing bin dir

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -112,6 +112,7 @@ install:
 	@echo "==== $(LUAJIT_LIBRARYDIR) and ===="
 	@echo "==== $(LUAJIT_MODULEDIR) ===="
 	$(MKDIR) $(INSTALL_LIB)
+	$(MKDIR) $(INSTALL_BIN)
 	$(MKDIR) $(LUA_MODULEDIR)/turbo
 	$(MKDIR) $(LUAJIT_MODULEDIR)/turbo
 	$(CP_R) turbo/* $(LUA_MODULEDIR)/turbo


### PR DESCRIPTION
Currently I'm ending up with a file /usr/bin which should be turbovisor