### PR TITLE
add rest api example with enables cores #225

### DIFF
--- a/examples/restapi/receiveJson.html
+++ b/examples/restapi/receiveJson.html
@@ -1,0 +1,18 @@
+<html>
+    <head>
+        <title>
+            turbo.lua cors example
+        </title>
+        <meta charset="UTF-8">
+        <!-- jquery -->
+        <script src="https://ajax.googleapis.com/ajax/libs/jquery/2.1.4/jquery.min.js"></script>
+    </head>
+    <body>
+        <script type="text/javascript">
+            $.getJSON( "http://localhost:8888/api",
+            function(data){
+                document.write(JSON.stringify(data));
+            });
+        </script>
+    </body>
+</html>

--- a/examples/restapi/restapi.lua
+++ b/examples/restapi/restapi.lua
@@ -1,0 +1,39 @@
+-- turbo.lua REST API example with enabled CORS
+local turbo = require("turbo")
+
+-- http://localhost:8888/api
+local api = class("api", turbo.web.RequestHandler)
+
+  -- see sendJson.html
+  -- or e.g. in python3.4
+  -- import json, requests
+  -- >>> requests.post('http://localhost:8888/api', json.dumps({'Hello': 'Json'}))
+  -- <Response [200]>
+  function api:post()
+    self:add_header('Access-Control-Allow-Origin','*')
+    local json = self:get_json(true)
+    for key,value in pairs(json) do print(key,value) end -- output in terminal!
+  end
+  
+  -- see receiveJson.html
+  -- or e.g. in python3.4
+  -- import json, requests
+  -- >>> requests.get('http://localhost:8888/api').content
+  -- b'{"hello":"json"}'
+  function api:get()
+    self:add_header('Access-Control-Allow-Origin','*')
+    self:write({hello="json"}) -- return json in browser
+  end
+  
+  -- CORS preflight request
+  function api:options()
+    self:add_header('Access-Control-Allow-Methods', 'POST')
+    self:add_header('Access-Control-Allow-Headers', 'content-type')
+    self:add_header('Access-Control-Allow-Origin', '*')
+  end
+  
+  
+turbo.web.Application({
+    {"/api", api}
+}):listen(8888)
+turbo.ioloop.instance():start()

--- a/examples/restapi/sendJson.html
+++ b/examples/restapi/sendJson.html
@@ -1,0 +1,29 @@
+<html>
+    <head>
+        <meta content='text/html; charset=utf-8' http-equiv='content-type'>
+          <title>CORS AJAX JSON request</title>
+          <script type='text/javascript' src='https://ajax.googleapis.com/ajax/libs/jquery/2.1.4/jquery.min.js'></script>
+      <script type='text/javascript'>
+        $(document).ready(function()
+        {
+          $('button').on('click', function()
+          {
+            $.ajax({
+              'type'        : 'POST',
+              'dataType'    : 'JSON',
+              'contentType' : 'application/json',
+              'url'         : 'http://localhost:8888/api',
+              'data'        : JSON.stringify({'foo': 'bar'}),
+              'success'     : function(response)
+              {
+                console.log(response);  
+              }
+            });
+          })
+        });
+      </script>
+   </head>
+   <body>
+        <button>make request</button>
+   </body>
+</html>


### PR DESCRIPTION
In relation to my issue #225, I've added a working example with enabled cors.