### PR TITLE
OS X build improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 doc/_build
 *.so.*
 *.so
+*.dylib
 *.dSYM
 *.o
 *.swp

--- a/Makefile
+++ b/Makefile
@@ -95,11 +95,11 @@ uninstall:
 	@echo "==== Uninstalling Turbo.lua ===="
 ifeq ($(uname_S),Linux)
 	$(UNINSTALL) $(INSTALL_TFFI_WRAP_SHORT) $(INSTALL_TFFI_WRAP_DYN)
+	$(LDCONFIG) $(INSTALL_LIB)
 endif
 ifeq ($(uname_S),Darwin)
 	$(UNINSTALL) $(INSTALL_TFFI_WRAP_SHORT)
 endif
-	$(LDCONFIG) $(INSTALL_LIB)
 	$(UNINSTALL) $(LUA_MODULEDIR)/turbo/
 	$(UNINSTALL) $(LUAJIT_MODULEDIR)/turbo/
 	$(UNINSTALL) $(INSTALL_BIN)/turbovisor

--- a/deps/turbo_ffi_wrap.c
+++ b/deps/turbo_ffi_wrap.c
@@ -173,8 +173,8 @@ int32_t validate_hostname(const char *hostname, const SSL *server){
     X509_free(server_cert);
     return result;
 }
-#endif
 #pragma GCC diagnostic pop
+#endif
 
 bool url_field_is_set(
         const struct http_parser_url *url,


### PR DESCRIPTION
In particular: fix `make SSL=none` by enclosing the #pragma pop within
the #ifndef TURBO_NO_SSL to prevent unknown pragmas warning with clang.

Also: skip `ldconfig` at uninstall time (Makefile).