### PR TITLE
iostream: reread resolv.conf if getaddrinfo() returns EAI_AGAIN

### DIFF
--- a/turbo/cdef.lua
+++ b/turbo/cdef.lua
@@ -157,6 +157,7 @@ end
             struct addrinfo **res);
         void freeaddrinfo(struct addrinfo *ai);
         const char *gai_strerror(int ecode);
+        int __res_init(void);
     ]]
 
 

--- a/turbo/iostream.lua
+++ b/turbo/iostream.lua
@@ -45,7 +45,7 @@ require "turbo.cdef"
 require "turbo.3rdparty.middleclass"
 
 local SOCK_STREAM, AF_UNSPEC, EWOULDBLOCK, EINPROGRESS, ECONNRESET, EPIPE,
-    EAGAIN
+    EAGAIN, EAI_AGAIN
 
 if platform.__LINUX__  and not _G.__TURBO_USE_LUASOCKET__ then
     SOCK_STREAM = socket.SOCK_STREAM
@@ -55,6 +55,7 @@ if platform.__LINUX__  and not _G.__TURBO_USE_LUASOCKET__ then
     ECONNRESET =  socket.ECONNRESET
     EPIPE =       socket.EPIPE
     EAGAIN =      socket.EAGAIN
+    EAI_AGAIN =   socket.EAI_AGAIN
 end
 
 local bitor, bitand, min, max =  bit.bor, bit.band, math.min, math.max
@@ -145,6 +146,9 @@ if platform.__LINUX__ and not _G.__TURBO_USE_LUASOCKET__ then
         hints[0].ai_protocol = 0
         rc = ffi.C.getaddrinfo(address, tostring(port), hints, servinfo)
         if rc ~= 0 then
+            if rc == -EAI_AGAIN then
+                ffi.C.__res_init()
+            end
             return -1, string.format("Could not resolve hostname '%s': %s",
                 address, ffi.string(C.gai_strerror(rc)))
         end

--- a/turbo/socket_ffi.lua
+++ b/turbo/socket_ffi.lua
@@ -288,7 +288,8 @@ E = {
     EWOULDBLOCK =       11,
     EINPROGRESS =       150,
     ECONNRESET =        131,
-    EPIPE =             32
+    EPIPE =             32,
+    EAI_AGAIN =         3
 }
 else
 E = {
@@ -296,7 +297,8 @@ E = {
     EWOULDBLOCK =       11,
     EINPROGRESS =       115,
     ECONNRESET =        104,
-    EPIPE =             32
+    EPIPE =             32,
+    EAI_AGAIN =         3
 }
 end
 


### PR DESCRIPTION
When /etc/resolv.conf was changed (i.e. by new PPP connection), turbo is still using previously cached resolv.conf content (this  is a GLIBC feature).  Every connect trial fails with error:

` [async.lua] Error code -3. Could not resolve hostname 'myhostname.com': Temporary failure in name resolution`

Solution is to call res_init() function when getaddrinfo() return -3 (EAI_AGAIN).