### PR TITLE
HTTPParser class does not has field named version

### DIFF
--- a/turbo/httpserver.lua
+++ b/turbo/httpserver.lua
@@ -223,7 +223,7 @@ function httpserver.HTTPConnection:_on_headers(data)
     self._headers_read = true
     self._request = httpserver.HTTPRequest:new(headers:get_method(),
         headers:get_url(), {
-            version = headers.version,
+            version = headers:get_version(),
             connection = self,
             headers = headers,
             remote_ip = self.address


### PR DESCRIPTION
keepalive client requests are getting closed, as requests
are always treated as HTTP/1.0. in code "headers.version"
is always comes as 'nil'. it is corrected to "headers:get_version()"