### PR TITLE
FIXED: websocket close callback not called when websocket server got …

### DIFF
--- a/turbo/iostream.lua
+++ b/turbo/iostream.lua
@@ -705,7 +705,7 @@ else
             local ptr, sz = self._luasocket_buf:get()
             return ptr, sz, closed
         else
-            return
+            return nil, nil, closed
         end
     end
 end
@@ -715,6 +715,10 @@ end
 function iostream.IOStream:_read_to_buffer()
     local ptr, sz, closed = self:_read_from_socket()
     if not ptr then
+        if closed then
+            self:close()
+            return
+        end
         return 0
     end
     self._read_buffer:append_right(ptr, sz)


### PR DESCRIPTION
…killed

closed flag was ignored in some cases in iostream class