### PR TITLE
Some dirty fixes

### DIFF
--- a/turbo/iostream.lua
+++ b/turbo/iostream.lua
@@ -1819,6 +1819,7 @@ if platform.__LINUX__ and not _G.__TURBO_USE_LUASOCKET__ then
                     local servinfo, sockaddr =
                         _unpack_addrinfo(packed_servinfo)
                     iostream._dns_cache[self.cache_id] = servinfo
+                    getmetatable(iostream._dns_cache)[self.cache_id] = sockaddr
                     _self.ctx:set_arguments({false, servinfo})
                     _self.ctx:finalize_context()
                 end)

--- a/turbo/socket_ffi.lua
+++ b/turbo/socket_ffi.lua
@@ -286,6 +286,7 @@ if ffi.arch == "mipsel" then
 E = {
     EAGAIN =            11,
     EWOULDBLOCK =       11,
+    EAFNOSUPPORT =      124,
     EINPROGRESS =       150,
     ECONNRESET =        131,
     EPIPE =             32,
@@ -295,6 +296,7 @@ else
 E = {
     EAGAIN =            11,
     EWOULDBLOCK =       11,
+    EAFNOSUPPORT =      97,
     EINPROGRESS =       115,
     ECONNRESET =        104,
     EPIPE =             32,

--- a/turbo/sockutil.lua
+++ b/turbo/sockutil.lua
@@ -43,6 +43,7 @@ if platform.__LINUX__ and not _G.__TURBO_USE_LUASOCKET__ then
     local EINPROGRESS = socket.EINPROGRESS
     local EWOULDBLOCK = socket.EWOULDBLOCK
     local EAGAIN =      socket.EAGAIN
+    local EAFNOSUPPORT = socket.EAFNOSUPPORT
     local INET_ADDRSTRLEN = 16
     local INET6_ADDRSTRLEN = 46
 
@@ -112,19 +113,16 @@ if platform.__LINUX__ and not _G.__TURBO_USE_LUASOCKET__ then
     function sockutils.connect_addrinfo(sock, p)
         local r = 0
         local errno = 0
-        while 1 do
-            if p == nil then
-                return nil, "Could not connect"
+        if p == nil then
+            return nil, "Could not connect"
+        end
+        r = C.connect(sock, p.ai_addr, p.ai_addrlen)
+        if r ~= 0 then
+            errno = ffi.errno()
+            if errno == EINPROGRESS then
+                return p
             end
-            r = C.connect(sock, p.ai_addr, p.ai_addrlen)
-            if r ~= 0 then
-                errno = ffi.errno()
-                if errno == EINPROGRESS then
-                    break
-                end
-            else
-                break
-            end
+            return nil, string.format("Could not connect. Errno %d: %s", errno, socket.strerror(errno) or "")
         end
         return p
     end

--- a/turbo/websocket.lua
+++ b/turbo/websocket.lua
@@ -182,7 +182,7 @@ end
 --- Close the connection.
 function websocket.WebSocketStream:close()
     self._closed = true
-    _self = self
+    local _self = self
     self:_send_frame(true, websocket.opcode.CLOSE, "", function()
         _self.stream:close()
     end)


### PR DESCRIPTION
Fix about DNSResolv data is necessary, without it my web socket client is not working properly.  My fast fix is to store 'sockaddr' reference in  in metatable. In future DNSResolv  can implement methods to do this in more elegant way.

Issue with DNSResolv discovers issue with error handling from C.connect() call, which can lead to program hang. My changes only shows idea of fix, but I don't know Turbo internals to do this properly.
