### PR TITLE
handle ssl handshake failure with luasocket

### DIFF
--- a/turbo/iostream.lua
+++ b/turbo/iostream.lua
@@ -1500,6 +1500,8 @@ elseif _G.TURBO_SSL then
             end
         elseif err == "wantread" then
             self:_add_io_state(ioloop.READ)
+        else
+            self:close()
         end
     end
 


### PR DESCRIPTION
if https server is run with luasocket and plain http request
is sent, results in high cpu usage. the reason is it keeps
trying to parse handshake request inspite of error