### PR TITLE
http-parser: Fix typo in switch FALLTHROUGH comment

### DIFF
--- a/deps/http-parser/http_parser.c
+++ b/deps/http-parser/http_parser.c
@@ -2095,7 +2095,7 @@ http_parser_parse_url(
       case s_req_server_with_at:
         found_at = 1;
 
-      /* FALLTROUGH */
+      /* FALLTHROUGH */
       case s_req_server:
         uf = UF_HOST;
         break;


### PR DESCRIPTION
This also suppresses -Wimplicit-fallthrough warning, which is enabled
in gcc7 by default.