### PR TITLE
iostream: Fix initial read for FFI sockets

### DIFF
--- a/turbo/iostream.lua
+++ b/turbo/iostream.lua
@@ -644,6 +644,9 @@ if platform.__LINUX__ and not _G.__TURBO_USE_LUASOCKET__ then
             errno = ffi.errno()
             if errno == EWOULDBLOCK or errno == EAGAIN then
                 return
+            elseif errno == ECONNRESET then
+                self:close()
+                return nil
             else
                 local fd = self.socket
                 self:close()


### PR DESCRIPTION
When running httpserver.lua example and executing
'nmap localhost -p 8888' command we get error listed below.
After that it is no longer possible to handle HTTP requests.

  [mniestroj@gm examples]$ luajit httpserver.lua
  [E 2018/01/26 17:00:56] [ioloop.lua] Error in IOLoop handler.
  ▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼
  /usr/local/share/lua/5.1/turbo/iostream.lua:650: Error when reading from socket 5. Errno: 104. Connection reset by peer
  stack traceback:
          [C]: in function 'error'
          /usr/local/share/lua/5.1/turbo/iostream.lua:650: in function '_read_from_socket'
          /usr/local/share/lua/5.1/turbo/iostream.lua:725: in function '_read_to_buffer'
          /usr/local/share/lua/5.1/turbo/iostream.lua:467: in function '_initial_read'
          /usr/local/share/lua/5.1/turbo/iostream.lua:200: in function 'read_until'
          /usr/local/share/lua/5.1/turbo/httpserver.lua:130: in function 'initialize'
          ...share/lua/5.1/turbo/3rdparty/middleclass/middleclass.lua:90: in function 'HTTPConnection'
          /usr/local/share/lua/5.1/turbo/httpserver.lua:101: in function 'handle_stream'
          /usr/local/share/lua/5.1/turbo/tcpserver.lua:213: in function </usr/local/share/lua/5.1/turbo/tcpserver.lua:200>
          /usr/local/share/lua/5.1/turbo/sockutil.lua:244: in function </usr/local/share/lua/5.1/turbo/sockutil.lua:204>
          [C]: in function 'xpcall'
          /usr/local/share/lua/5.1/turbo/ioloop.lua:546: in function '_run_handler'
          /usr/local/share/lua/5.1/turbo/ioloop.lua:454: in function '_event_poll'
          /usr/local/share/lua/5.1/turbo/ioloop.lua:443: in function 'start'
          httpserver.lua:43: in main chunk
          [C]: at 0x00404680
  ▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲

This bug is only reproducible when socket is closed just after
opening, as it is in case of nmap command above. The root cause is
that we try to read from socket just after opening it. We get an
ECONNRESET error, because there socket was closed immediately.

Watch for ECONNRESET error during read, so we make sure immediately
closed connection are handled properly.