### PR TITLE
httputil: do not error when parameter is incorrectly encoded

### DIFF
--- a/turbo/httputil.lua
+++ b/turbo/httputil.lua
@@ -219,7 +219,11 @@ function httputil.HTTPParser:get_status_code()
     return self.tpw.parser.status_code, status_codes[self.status_code]
 end
 
-local function _unescape(s) return string.char(tonumber(s,16)) end
+local function _unescape(s)
+    local n = tonumber(s,16)
+    if n then return string.char(n) end
+end
+
 --- Internal function to parse ? and & separated key value fields.
 -- @param uri (String)
 local function _parse_arguments(uri)


### PR DESCRIPTION
This should pass the parameter as is.