### PR TITLE
util.lua: fix for assign to undeclared variable "start" (in fn "strsp…

### DIFF
--- a/turbo/util.lua
+++ b/turbo/util.lua
@@ -43,7 +43,7 @@ function util.strsplit(str, sep, max, pattern)
     if str:len() > 0 then
         local plain = not pattern
         max = max or -1
-        local field=1 start=1
+        local field, start = 1, 1
         local first, last = str:find(sep, start, plain)
         while first and max ~= 0 do
             record[field] = str:sub(start, first-1)


### PR DESCRIPTION
…lit")
```
[web.lua] Error in RequestHandler, thread: 0x41bf7ae0 is dead.
▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼
/usr/local/share/lua/5.1/turbo/util.lua:46:

strict2.lua: assign to undeclared variable "start" (in fn "strsplit")

stack traceback:
	/usr/local/share/lua/5.1/turbo/httpserver.lua:251: in function
</usr/local/share/lua/5.1/turbo/httpserver.lua:212>
	[C]: in function 'xpcall'
	/usr/local/share/lua/5.1/turbo/iostream.lua:565: in function
</usr/local/share/lua/5.1/turbo/iostream.lua:556>
	[C]: in function 'xpcall'
	/usr/local/share/lua/5.1/turbo/ioloop.lua:578: in function
</usr/local/share/lua/5.1/turbo/ioloop.lua:577>
▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲
```