### PR TITLE
socket_ffi.lua: correct luasocket variable name

### DIFF
--- a/turbo/socket_ffi.lua
+++ b/turbo/socket_ffi.lua
@@ -434,9 +434,9 @@ else
             "LuaSocket only support SOCK_DGRAM and SOCK_STREAM.")
         local sock
         if stype == SOCK.SOCK_DGRAM then
-            sock = socket.udp()
+            sock = luasocket.udp()
         elseif stype == SOCK.SOCK_STREAM then
-            sock = socket.tcp()
+            sock = luasocket.tcp()
         end
         sock:settimeout(0)
         sock:setoption("keepalive", true)


### PR DESCRIPTION
Because turbo has issues with #343 I have tried to use the lua socket option but found out it was broken.
It also looks like the lua socket option doesn't support http redirects?