### PR TITLE
Fix race condition in iostream.lua when using HTTPConnection

### DIFF
--- a/turbo/iostream.lua
+++ b/turbo/iostream.lua
@@ -610,13 +610,13 @@ function iostream.IOStream:_handle_read()
         if self:_read_to_buffer() == 0 then
             break
         end
+        -- Give a chance to run scheduled callback before we read all data.
+        if self:_read_from_buffer() == true then
+            break
+        end
     end
     self._pending_callbacks = self._pending_callbacks - 1
-    if self:_read_from_buffer() == true then
-        return
-    else
-        self:_maybe_run_close_callback()
-    end
+    self:_maybe_run_close_callback()
 end
 
 --- Reads from the socket. Return the data chunk or nil if theres nothing to


### PR DESCRIPTION
When we are expecting next request (Connection: keep-alive) it is
possible '_initial_read()' will not gather any data because they are not
in the socket yet so expected HTTP header will not be found. Hence data
will be read to buffer from event handler. But in '_handle_read()' data
are read to buffer until EWOULDBLOCK appears before it calls
'_read_from_buffer()' again. So when request body is big it is possible
it will not fit into buffer which is prepared just for header size
(1024*18).

The solution is to call '_read_from_buffer()' every time when new data
are pushed to buffer.