### PR TITLE
Add stat support for osx.

### DIFF
--- a/turbo/cdef.lua
+++ b/turbo/cdef.lua
@@ -559,6 +559,43 @@ if platform.__LINUX__ then
     ]]
 end
 
+if platform.__DARWIN__ then
+    if not S then
+        ffi.cdef[[
+            struct stat {
+                unsigned int       st_dev;
+                unsigned short     st_mode;
+                unsigned short     st_nlink;
+                unsigned long long st_ino;
+                unsigned int       st_uid;
+                unsigned int       st_gid;
+                unsigned int       st_rdev;
+                unsigned int       __pad0;
+                long               st_atime;
+                long               st_atime_nsec;
+                long               st_mtime;
+                long               st_mtime_nsec;
+                long               st_ctime;
+                long               st_ctime_nsec;
+                long               st_birthtime;
+                long               st_birthtime_nsec;
+                long long          st_size;
+                long long          st_blocks;
+                int                st_blksize;
+                unsigned int       st_flags;
+                unsigned int       st_gen;
+                int                st_lspare;
+                long long          st_qspare[2];
+            };
+        ]]
+    end
+
+    --- ******* File system *******
+    ffi.cdef[[
+        int syscall(int number, ...);
+        int fstat(int fd, struct stat *buf);
+    ]]
+end
 
 if _G.TURBO_SSL then
     --- *******OpenSSL *******
@@ -611,7 +648,7 @@ if _G.TURBO_SSL then
             const char *file,
             int type);
         int SSL_CTX_use_certificate_chain_file(
-            SSL_CTX *ctx, 
+            SSL_CTX *ctx,
             const char *file);
         int SSL_CTX_load_verify_locations(
             SSL_CTX *ctx,

--- a/turbo/syscall.lua
+++ b/turbo/syscall.lua
@@ -16,6 +16,7 @@
 -- modes
 
 local ffi = require "ffi"
+local platform = require "turbo.platform"
 local util = require "turbo.util"
 local tm = util.tablemerge
 local octal = function (s) return tonumber(s, 8) end
@@ -51,7 +52,13 @@ local flags = {
 
 local cmds
 --- ******* syscalls *******
-if ffi.arch == "x86" then
+if platform.__DARWIN__ then
+    cmds = {
+        SYS_stat             = 338,
+        SYS_fstat            = 339,
+        SYS_lstat            = 340
+    }
+elseif ffi.arch == "x86" then
     cmds = {
         SYS_stat             = 106,
         SYS_fstat            = 108,


### PR DESCRIPTION
stat support was only available on Linux platform, while serving a static file requires fs.stat, which in turn invokes stat syscall, resulting in error "stdin:1: undeclared or implicit tag 'stat'"
This PR added stat support for osx (Darwin) so that serving static file works.