### PR TITLE
turbo/web.lua: overwrite Content-Type header instead of adding new one

### DIFF
--- a/turbo/web.lua
+++ b/turbo/web.lua
@@ -483,7 +483,7 @@ function web.RequestHandler:write(chunk)
     elseif t == "string" and chunk:len() == 0 then
         return
     elseif t == "table" then
-        self:add_header("Content-Type", "application/json; charset=UTF-8")
+        self:set_header("Content-Type", "application/json; charset=UTF-8")
         chunk = escape.json_encode(chunk)
     elseif t ~= "string" and t ~= "table" then
         error("Unsupported type written as response; "..t)


### PR DESCRIPTION
turbo/web.lua: overwrite Content-Type header instead of adding new one when returning json

This change prevents the web server from returning 2 "Content-Type" headers instead of one
if a "Content-Type" header was already added as one of the default headers (in
turbo.web.RequestHandler:set_default_headers). Now there will be one Content-Type header at
most.

The reason is that it is useful to set as default header "Content-type: text/plain" when
you want to return that content (and not the default text/html) for 4xx and 5xx return codes
while returning json for 200. Without the present commit, in the happy path (200 return code),
the web server returned 2 Content-type headers (text/plain and application/json).