### PR TITLE
Multiple bugfixes, security issue and CI improvements

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,14 @@
+# Keep host build artifacts out of the image; they are rebuilt inside it and
+# platform-specific objects (e.g. macOS .dylib/.o) break the Linux link step.
+.git
+*.dylib
+*.dylib.dSYM
+*.dSYM
+*.so
+*.so.*
+*.o
+*.luac
+deps/http-parser/*.o
+deps/http-parser/libhttp_parser*
+package/
+*.tar.gz

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,6 @@
 # Turbo.lua continuous integration.
 #
-# Copyright (C) 2026 John Abrahamsen.
+# Copyright 2026 John Abrahamsen
 # See LICENSE file for license information.
 #
 # Builds the test image (see Dockerfile) and runs the unit test suite under

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,23 @@
+# Turbo.lua continuous integration.
+#
+# Copyright (C) 2026 John Abrahamsen.
+# See LICENSE file for license information.
+#
+# Builds the test image (see Dockerfile) and runs the unit test suite under
+# LuaJIT on Linux. Replaces the defunct Travis CI setup.
+name: tests
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  docker:
+    name: Unit tests (Docker / LuaJIT)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Run unit test suite in Docker
+        run: make docker-test

--- a/Dockerfile
+++ b/Dockerfile
@@ -53,4 +53,5 @@ CMD ["spec/security_spec.lua", \
      "spec/util_spec.lua", \
      "spec/structs_spec.lua", \
      "spec/hash_spec.lua", \
-     "spec/httputil_spec.lua"]
+     "spec/httputil_spec.lua", \
+     "spec/server_spec.lua"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # Turbo.lua test image.
 #
-# Copyright (C) 2026 John Abrahamsen.
+# Copyright 2026 John Abrahamsen
 # See LICENSE file for license information.
 #
 # Builds Turbo against LuaJIT on Debian and runs the busted test suite.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,56 @@
+# Turbo.lua test image.
+#
+# Copyright (C) 2026 John Abrahamsen.
+# See LICENSE file for license information.
+#
+# Builds Turbo against LuaJIT on Debian and runs the busted test suite.
+# Replaces the (defunct) Travis CI setup with a reproducible Linux environment.
+#
+# Build:  docker build -t turbo-test .
+# Test:   docker run --rm turbo-test                      # default: unit specs
+#         docker run --rm turbo-test spec/web_spec.lua    # run a specific spec
+#         docker run --rm turbo-test spec/                # attempt every spec
+#
+# The default CMD runs only the deterministic, self-contained unit specs. The
+# HTTP/async/iostream specs are intentionally excluded from the default run:
+# they require real outbound network (e.g. async_spec fetches google.com with a
+# 60s wait) and a working loopback HTTP path that does not behave reliably in a
+# headless container, so they hang or time out regardless of code correctness.
+#
+# The image runs on whatever architecture the daemon uses; on Apple Silicon
+# this is linux/arm64, which also exercises the ARM64 syscall code paths.
+FROM debian:bookworm-slim
+
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends \
+        luajit libluajit-5.1-dev \
+        luarocks \
+        build-essential libssl-dev \
+        git ca-certificates \
+ && rm -rf /var/lib/apt/lists/*
+
+# busted installs into the lua 5.1 rock tree (LuaJIT is 5.1-compatible). The
+# generated wrapper hardcodes the PUC lua5.1 interpreter, which lacks FFI, so
+# we invoke the rock's entry point under luajit instead (see busted-luajit).
+RUN luarocks install busted
+
+COPY docker/busted-luajit /usr/local/bin/busted-luajit
+RUN chmod +x /usr/local/bin/busted-luajit
+
+WORKDIR /turbo
+COPY . /turbo
+
+# Build libtffi_wrap.so (and http-parser). make clean first to drop any host
+# build artifacts that may have been copied in.
+RUN make clean >/dev/null 2>&1 || true; make
+
+ENV TURBO_LIBTFFI=/turbo/libtffi_wrap.so
+ENV TURBO_SSL=1
+
+ENTRYPOINT ["busted-luajit"]
+CMD ["spec/security_spec.lua", \
+     "spec/mustache_spec.lua", \
+     "spec/util_spec.lua", \
+     "spec/structs_spec.lua", \
+     "spec/hash_spec.lua", \
+     "spec/httputil_spec.lua"]

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 ########
 ## Turbo.lua Makefile for installation.
-## Copyright (C) 2013 John Abrahamsen.
+## Copyright (C) 2013, 2026 John Abrahamsen.
 ## See LICENSE file for license information.
 ########
 
@@ -188,6 +188,19 @@ package: all minimize
 	$(TAR) turbo.$(MAJVER).$(MINVER).$(MICVER).tar.gz package
 	@echo "==== Created turbo.$(MAJVER).$(MINVER).$(MICVER).tar.gz package: ===="
 	md5sum turbo.$(MAJVER).$(MINVER).$(MICVER).tar.gz
+
+DOCKER_IMAGE ?= turbo-test
+
+docker-build:
+	@echo "==== Building Turbo.lua test image ($(DOCKER_IMAGE)) ===="
+	docker build -t $(DOCKER_IMAGE) .
+
+# Run the unit test suite in a reproducible Linux/LuaJIT container. Pass extra
+# busted arguments via ARGS, e.g. `make docker-test ARGS="spec/web_spec.lua"`.
+# See Dockerfile for why the HTTP/async specs are excluded from the default run.
+docker-test: docker-build
+	@echo "==== Running Turbo.lua tests in container ===="
+	docker run --rm $(DOCKER_IMAGE) $(ARGS)
 
 test:
 	@echo "==== Running tests for Turbo.lua. NOTICE: busted module is required ===="

--- a/README.rst
+++ b/README.rst
@@ -27,8 +27,8 @@ It's main features and design principles are:
 
 - SSL support (requires OpenSSL or LuaSec module for Windows)
 
-.. image:: https://api.travis-ci.org/kernelsauce/turbo.png
-   :target: http://travis-ci.org/kernelsauce/turbo
+.. image:: https://github.com/kernelsauce/turbo/actions/workflows/test.yml/badge.svg
+   :target: https://github.com/kernelsauce/turbo/actions/workflows/test.yml
 
 Supported Architectures
 -----------------------

--- a/deps/turbo_ffi_wrap.c
+++ b/deps/turbo_ffi_wrap.c
@@ -309,6 +309,10 @@ void turbo_parser_wrapper_exit(struct turbo_parser_wrapper *src)
     for (; i < src->hkv_sz; i++){
         free(src->hkv[i]);
     }
+    /* A trailing field with no value is allocated at hkv[hkv_sz] but not yet
+     * counted (hkv_sz bumps on the value), so free it here or it leaks. */
+    if (src->_state == FIELD)
+        free(src->hkv[src->hkv_sz]);
     free(src->hkv);
     free(src);
 }

--- a/docker/busted-luajit
+++ b/docker/busted-luajit
@@ -1,7 +1,7 @@
 #!/bin/sh
 # Run busted under LuaJIT.
 #
-# Copyright (C) 2026 John Abrahamsen.
+# Copyright 2026 John Abrahamsen
 # See LICENSE file for license information.
 #
 # luarocks installs busted into the lua 5.1 rock tree and generates a wrapper

--- a/docker/busted-luajit
+++ b/docker/busted-luajit
@@ -1,0 +1,26 @@
+#!/bin/sh
+# Run busted under LuaJIT.
+#
+# Copyright (C) 2026 John Abrahamsen.
+# See LICENSE file for license information.
+#
+# luarocks installs busted into the lua 5.1 rock tree and generates a wrapper
+# that execs the PUC `lua5.1` interpreter -- which has no FFI, so Turbo fails
+# to load. Instead we invoke the rock's actual busted entry point directly
+# under luajit, with the luarocks module paths prepended.
+set -e
+
+BUSTED_ENTRY=$(ls /usr/local/lib/luarocks/rocks-5.1/busted/*/bin/busted 2>/dev/null | head -1)
+if [ -z "$BUSTED_ENTRY" ]; then
+    echo "busted-luajit: could not locate the busted rock entry point" >&2
+    exit 1
+fi
+
+# Run with stdin from /dev/null. Without a real stdin (e.g. `docker run`
+# without -i), the ioloop's poll can spin on fd 0, busy-looping with
+# "no handler for fd: 0" and starving the tests. The test runner never reads
+# stdin, so detaching it is safe.
+exec luajit \
+    -e 'package.path="/usr/local/share/lua/5.1/?.lua;/usr/local/share/lua/5.1/?/init.lua;"..package.path' \
+    -e 'package.cpath="/usr/local/lib/lua/5.1/?.so;"..package.cpath' \
+    "$BUSTED_ENTRY" "$@" </dev/null

--- a/spec/httputil_spec.lua
+++ b/spec/httputil_spec.lua
@@ -1,6 +1,6 @@
 --[[ Turbo Unit test
 
-Copyright 2013 John Abrahamsen
+Copyright 2013, 2026 John Abrahamsen
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -92,6 +92,17 @@ describe("turbo.httputil Namespace", function()
         assert.equal(headers:get_argument("param2")[1], "somethingelse")
         assert.equal(headers:get_argument("param2")[2], "somethingelseelse")
         assert.equal(type(headers:get_arguments()), "table")
+    end)
+
+    it("should return an empty string for an empty URL parameter", function()
+        local raw =
+            "GET /x?empty=&filled=value&trailing= HTTP/1.1\r\n"..
+            "Host: somehost.no\r\n\r\n"
+        local headers = turbo.httputil.HTTPParser(
+            raw, turbo.httputil.hdr_t["HTTP_REQUEST"])
+        assert.equal(headers:get_argument("empty")[1], "")
+        assert.equal(headers:get_argument("filled")[1], "value")
+        assert.equal(headers:get_argument("trailing")[1], "")
     end)
 
     it("should parse URLs correctly", function()

--- a/spec/mustache_spec.lua
+++ b/spec/mustache_spec.lua
@@ -158,4 +158,19 @@ describe("turbo.web.Mustache Namespace", function()
             "{{>p}}", {name=function() return "Bob" end}, {p="Hi {{name}}"}),
             "Hi Bob")
     end)
+
+    it("should render a function value that returns a number", function()
+        assert.equal(turbo.web.Mustache.render(
+            "{{n}} and {{{n}}}", {n=function() return 42 end}),
+            "42 and 42")
+        assert.equal(turbo.web.Mustache.render(
+            "{{#s}}{{v}}{{/s}}", {s={{v=function() return 5 end}}}),
+            "5")
+    end)
+
+    it("should render an empty string for a function value that returns nil",
+        function()
+        assert.equal(turbo.web.Mustache.render(
+            "[{{n}}]", {n=function() return nil end}), "[]")
+    end)
 end)

--- a/spec/mustache_spec.lua
+++ b/spec/mustache_spec.lua
@@ -1,6 +1,6 @@
 --- Turbo.lua Mustache test
 --
--- Copyright 2013 John Abrahamsen
+-- Copyright 2013, 2026 John Abrahamsen
 --
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.
@@ -105,5 +105,57 @@ describe("turbo.web.Mustache Namespace", function()
         assert.equal(turbo.web.Mustache.render(
             "{{  #test  }}Klein{{  /test     }}",
             {test="My website"}), "Klein")
+    end)
+
+    it("should render number values without escaping (triple mustache)", function()
+        assert.equal(turbo.web.Mustache.render(
+            "count={{{n}}}", {n=42}), "count=42")
+    end)
+
+    it("should render number values", function()
+        assert.equal(turbo.web.Mustache.render(
+            "I am {{age}} years old.", {age=27}),
+            "I am 27 years old.")
+        assert.equal(turbo.web.Mustache.render(
+            "{{>p}}", {n=7}, {p="n={{n}}"}), "n=7")
+    end)
+
+    it("should skip a falsey section that contains a nested section", function()
+        assert.equal(turbo.web.Mustache.render(
+            "{{#missing}}{{#inner}}x{{/inner}}LEAK{{/missing}}TAIL", {}),
+            "TAIL")
+    end)
+
+    it("should propagate safe mode into partials", function()
+        assert.has_error(function()
+            turbo.web.Mustache.render("{{>p}}", {}, {p="{{missing}}"}, true)
+        end)
+        assert.has_no.errors(function()
+            turbo.web.Mustache.render("{{>p}}", {}, {p="{{missing}}"})
+        end)
+    end)
+
+    it("should call a function value and render its result", function()
+        assert.equal(turbo.web.Mustache.render(
+            "Hello {{name}}!", {name=function() return "World" end}),
+            "Hello World!")
+    end)
+
+    it("should escape the result of a function value ({{x}})", function()
+        assert.equal(turbo.web.Mustache.render(
+            "{{html}}", {html=function() return "<b>" end}),
+            "&lt;b&gt;")
+    end)
+
+    it("should not escape the result of a function value ({{{x}}})", function()
+        assert.equal(turbo.web.Mustache.render(
+            "{{{html}}}", {html=function() return "<b>" end}),
+            "<b>")
+    end)
+
+    it("should call a function value inside a partial", function()
+        assert.equal(turbo.web.Mustache.render(
+            "{{>p}}", {name=function() return "Bob" end}, {p="Hi {{name}}"}),
+            "Hi Bob")
     end)
 end)

--- a/spec/security_spec.lua
+++ b/spec/security_spec.lua
@@ -73,10 +73,12 @@ describe("Security fixes", function()
         local secret = "test_cookie_secret_key"
 
         -- Build a valid cookie string the same way set_secure_cookie does.
-        local function make_cookie(value, s)
+        -- The cookie name is part of the signed message (but not stored).
+        local function make_cookie(name, value, s)
             local ts = tostring(math.floor(turbo.util.gettimeofday()))
             local len = tostring(#value)
-            local sig = hash.HMAC(s, string.format("%s|%s|%s", len, ts, value))
+            local sig = hash.HMAC(s,
+                string.format("%s|%s|%s|%s", name, len, ts, value))
             return string.format("%s|%s|%s|%s", sig, len, ts, value)
         end
 
@@ -95,29 +97,47 @@ describe("Security fixes", function()
 
         it("should accept a valid signed cookie", function()
             local val = "mysessiontoken"
-            local handler = make_handler("session", make_cookie(val, secret), secret)
+            local handler = make_handler("session",
+                make_cookie("session", val, secret), secret)
             assert.equal(handler:get_secure_cookie("session"), val)
         end)
 
-        it("should reject a cookie with a tampered HMAC", function()
-            local val = "mysessiontoken"
-            local cookie_str = make_cookie(val, secret)
-            -- Flip the first hex digit of the HMAC
-            local tampered = string.char((cookie_str:byte(1) + 1) % 256) ..
-                             cookie_str:sub(2)
+        -- Forged/stale cookies return the default, they do not raise.
+        it("should return the default for a tampered HMAC", function()
+            local cookie_str = make_cookie("session", "mysessiontoken", secret)
+            -- Flip one hex digit of the HMAC, keeping the format intact.
+            local c = cookie_str:sub(5, 5) == "a" and "b" or "a"
+            local tampered = cookie_str:sub(1, 4)..c..cookie_str:sub(6)
             local handler = make_handler("session", tampered, secret)
-            assert.has_error(function()
-                handler:get_secure_cookie("session")
-            end)
+            assert.equal(handler:get_secure_cookie("session", "fallback"),
+                "fallback")
         end)
 
-        it("should reject a cookie signed with a different secret", function()
-            local val = "mysessiontoken"
-            local cookie_str = make_cookie(val, "wrong_secret")
-            local handler = make_handler("session", cookie_str, secret)
-            assert.has_error(function()
-                handler:get_secure_cookie("session")
-            end)
+        it("should return the default for a cookie signed with another secret",
+            function()
+            local handler = make_handler("session",
+                make_cookie("session", "mysessiontoken", "wrong_secret"),
+                secret)
+            assert.is_nil(handler:get_secure_cookie("session"))
+        end)
+
+        it("should return the default for a malformed cookie", function()
+            local handler = make_handler("session", "not-a-cookie", secret)
+            assert.equal(handler:get_secure_cookie("session", "fallback"),
+                "fallback")
+        end)
+
+        -- Regression: the signature binds the name, so a value signed for one
+        -- cookie name must not validate under a different name.
+        it("should reject a value replayed under a different cookie name",
+            function()
+            local cookie_str = make_cookie("session", "mysessiontoken", secret)
+            local as_admin = make_handler("admin", cookie_str, secret)
+            assert.is_nil(as_admin:get_secure_cookie("admin"))
+            -- Sanity: still valid under its real name.
+            local as_session = make_handler("session", cookie_str, secret)
+            assert.equal(as_session:get_secure_cookie("session"),
+                "mysessiontoken")
         end)
 
     end)
@@ -154,25 +174,38 @@ describe("Security fixes", function()
             assert.equal(#turbo.util.rand_str(), 64)
         end)
 
-    end)
-
-    describe("crypto.ssl_init", function()
-
-        it("should initialize SSL without error", function()
-            local crypto = require "turbo.crypto"
-            assert.has_no.errors(function()
-                crypto.ssl_init()
-            end)
-        end)
-
-        it("should be idempotent when called repeatedly", function()
-            local crypto = require "turbo.crypto"
-            assert.has_no.errors(function()
-                crypto.ssl_init()
-                crypto.ssl_init()
-            end)
+        it("util.rand_str should only return printable characters", function()
+            -- Callers put this straight into cookies and headers.
+            for _, n in ipairs({1, 7, 20, 64}) do
+                local s = turbo.util.rand_str(n)
+                assert.equal(#s, n)
+                assert.truthy(s:match("^[0-9a-f]+$"))
+            end
         end)
 
     end)
+
+    -- ssl_init only exists in the OpenSSL backend. The LuaSocket builds use
+    -- LuaSec, which initializes itself.
+    if turbo.platform.__LINUX__ and not _G.__TURBO_USE_LUASOCKET__ then
+        describe("crypto.ssl_init", function()
+
+            it("should initialize SSL without error", function()
+                local crypto = require "turbo.crypto"
+                assert.has_no.errors(function()
+                    crypto.ssl_init()
+                end)
+            end)
+
+            it("should be idempotent when called repeatedly", function()
+                local crypto = require "turbo.crypto"
+                assert.has_no.errors(function()
+                    crypto.ssl_init()
+                    crypto.ssl_init()
+                end)
+            end)
+
+        end)
+    end
 
 end)

--- a/spec/security_spec.lua
+++ b/spec/security_spec.lua
@@ -1,0 +1,178 @@
+--- Turbo.lua Unit test
+--
+-- Copyright 2026 John Abrahamsen
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+-- http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+_G.__TURBO_USE_LUASOCKET__ = os.getenv("TURBO_USE_LUASOCKET") and true or false
+_G.TURBO_SSL = true
+
+local turbo = require "turbo"
+local hash = require "turbo.hash"
+
+describe("Security fixes", function()
+
+    before_each(function()
+        _G.io_loop_instance = nil
+    end)
+
+    describe("escape.html_escape", function()
+
+        it("should raise an error when passed a non-string (nil)", function()
+            assert.has_error(function()
+                turbo.escape.html_escape(nil)
+            end)
+        end)
+
+        it("should raise an error when passed a number", function()
+            assert.has_error(function()
+                turbo.escape.html_escape(42)
+            end)
+        end)
+
+        it("should raise an error when passed a table", function()
+            assert.has_error(function()
+                turbo.escape.html_escape({})
+            end)
+        end)
+
+        it("should escape HTML special characters in a valid string", function()
+            assert.equal(
+                turbo.escape.html_escape('<script>alert("xss")</script>'),
+                "&lt;script&gt;alert(&quot;xss&quot;)&lt;&#47;script&gt;"
+            )
+        end)
+
+        it("should escape ampersands", function()
+            assert.equal(turbo.escape.html_escape("a & b"), "a &amp; b")
+        end)
+
+        it("should escape single quotes", function()
+            assert.equal(turbo.escape.html_escape("it's"), "it&#39;s")
+        end)
+
+        it("should return unchanged string when no special chars present", function()
+            assert.equal(turbo.escape.html_escape("hello world"), "hello world")
+        end)
+
+    end)
+
+    -- get_secure_cookie is exercised via a minimal mock to avoid HTTP server
+    -- SSL loading-order issues under busted.
+    describe("secure cookies", function()
+        local secret = "test_cookie_secret_key"
+
+        -- Build a valid cookie string the same way set_secure_cookie does.
+        local function make_cookie(value, s)
+            local ts = tostring(math.floor(turbo.util.gettimeofday()))
+            local len = tostring(#value)
+            local sig = hash.HMAC(s, string.format("%s|%s|%s", len, ts, value))
+            return string.format("%s|%s|%s|%s", sig, len, ts, value)
+        end
+
+        -- Minimal mock: a table that inherits RequestHandler methods but has
+        -- just enough state for get_cookie / get_secure_cookie to work.
+        local function make_handler(cookie_name, cookie_str, s)
+            local headers = turbo.httputil.HTTPHeaders:new()
+            headers:set("Cookie", cookie_name .. "=" .. cookie_str)
+            return setmetatable({
+                request = { headers = headers },
+                application = { kwargs = { cookie_secret = s } },
+                _cookies_parsed = false,
+                _cookies = {},
+            }, { __index = turbo.web.RequestHandler })
+        end
+
+        it("should accept a valid signed cookie", function()
+            local val = "mysessiontoken"
+            local handler = make_handler("session", make_cookie(val, secret), secret)
+            assert.equal(handler:get_secure_cookie("session"), val)
+        end)
+
+        it("should reject a cookie with a tampered HMAC", function()
+            local val = "mysessiontoken"
+            local cookie_str = make_cookie(val, secret)
+            -- Flip the first hex digit of the HMAC
+            local tampered = string.char((cookie_str:byte(1) + 1) % 256) ..
+                             cookie_str:sub(2)
+            local handler = make_handler("session", tampered, secret)
+            assert.has_error(function()
+                handler:get_secure_cookie("session")
+            end)
+        end)
+
+        it("should reject a cookie signed with a different secret", function()
+            local val = "mysessiontoken"
+            local cookie_str = make_cookie(val, "wrong_secret")
+            local handler = make_handler("session", cookie_str, secret)
+            assert.has_error(function()
+                handler:get_secure_cookie("session")
+            end)
+        end)
+
+    end)
+
+    describe("util.secure_random_bytes", function()
+
+        it("should return a string", function()
+            local r = turbo.util.secure_random_bytes(16)
+            assert.is_string(r)
+        end)
+
+        it("should return exactly the requested number of bytes", function()
+            for _, n in ipairs({1, 4, 16, 32, 64, 256}) do
+                assert.equal(#turbo.util.secure_random_bytes(n), n)
+            end
+        end)
+
+        it("should return different values on successive calls", function()
+            local a = turbo.util.secure_random_bytes(32)
+            local b = turbo.util.secure_random_bytes(32)
+            local c = turbo.util.secure_random_bytes(32)
+            assert.not_equal(a, b)
+            assert.not_equal(b, c)
+            assert.not_equal(a, c)
+        end)
+
+        it("util.rand_str should use secure_random_bytes and return correct length", function()
+            local s = turbo.util.rand_str(20)
+            assert.is_string(s)
+            assert.equal(#s, 20)
+        end)
+
+        it("util.rand_str default length should be 64 bytes", function()
+            assert.equal(#turbo.util.rand_str(), 64)
+        end)
+
+    end)
+
+    describe("crypto.ssl_init", function()
+
+        it("should initialize SSL without error", function()
+            local crypto = require "turbo.crypto"
+            assert.has_no.errors(function()
+                crypto.ssl_init()
+            end)
+        end)
+
+        it("should be idempotent when called repeatedly", function()
+            local crypto = require "turbo.crypto"
+            assert.has_no.errors(function()
+                crypto.ssl_init()
+                crypto.ssl_init()
+            end)
+        end)
+
+    end)
+
+end)

--- a/spec/server_spec.lua
+++ b/spec/server_spec.lua
@@ -1,0 +1,51 @@
+--- Turbo.lua Unit test
+--
+-- Copyright 2026 John Abrahamsen
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+-- http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+_G.TURBO_SSL = false
+_G.__TURBO_USE_LUASOCKET__ = os.getenv("TURBO_USE_LUASOCKET") and true or false
+local turbo = require "turbo"
+
+-- A minimal localhost request/response round-trip. This exercises the event
+-- loop end to end (accept, read, write via epoll/kqueue). It regression-guards
+-- the aarch64 epoll_event layout bug, where a packed struct misread epoll_wait
+-- results, spun the loop on "no handler for fd: 0" and served nothing.
+describe("HTTP server round-trip", function()
+
+    before_each(function()
+        _G.io_loop_instance = nil
+    end)
+
+    it("serves a request through the event loop", function()
+        local port = math.random(20000, 40000)
+        local io = turbo.ioloop.instance()
+        local Handler = class("Handler", turbo.web.RequestHandler)
+        function Handler:get() self:write("pong") end
+        turbo.web.Application({{"^/$", Handler}}):listen(port)
+
+        local code, body
+        io:add_callback(function()
+            local res = coroutine.yield(turbo.async.HTTPClient():fetch(
+                "http://127.0.0.1:" .. tostring(port) .. "/"))
+            code, body = res.code, res.body
+            io:close()
+        end)
+        io:wait(5)
+
+        assert.equal(code, 200)
+        assert.equal(body, "pong")
+    end)
+
+end)

--- a/spec/structs_spec.lua
+++ b/spec/structs_spec.lua
@@ -1,6 +1,6 @@
 --- Turbo.lua Unit test
 --
--- Copyright 2013 John Abrahamsen
+-- Copyright 2013, 2026 John Abrahamsen
 --
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.
@@ -88,6 +88,20 @@ describe("turbo.structs Namespace", function()
             local buf = turbo.structs.buffer()
             buf:append_luastr_left("test"):append_luastr_left("test")
             assert.equal(tostring(buf), "testtest")
+        end)
+        it("should grow past the 1MB threshold without corrupting data", function()
+            local buf = turbo.structs.buffer()
+            local chunk = string.rep("A", 64 * 1024)  -- 64KB
+            local n = 40                                -- 2.5MB total
+            for _ = 1, n do
+                buf:append_luastr_right(chunk)
+            end
+            local total = #chunk * n
+            assert.equal(buf:len(), total)
+            local s = tostring(buf)
+            assert.equal(#s, total)
+            -- Every byte must still be "A" -- no garbage from a bad realloc.
+            assert.is_nil(s:find("[^A]"))
         end)
     end)
 

--- a/turbo/cdef.lua
+++ b/turbo/cdef.lua
@@ -322,7 +322,11 @@ if platform.__LINUX__ then
                 uint64_t u64;
             } epoll_data_t;
         ]]
-        if platform.__ABI32__ or platform.__PPC64__ then
+        if platform.__ABI32__ or platform.__PPC64__ or platform.__ARM64__ then
+            -- epoll_event is packed only on x86/x86_64 (to match the i386
+            -- layout). On aarch64, ppc64 etc. it is naturally aligned, so
+            -- packing it here misreads epoll_wait results (events appear with
+            -- fd 0) and spins the loop.
             ffi.cdef[[
                 struct epoll_event{
                     unsigned int events;

--- a/turbo/cdef.lua
+++ b/turbo/cdef.lua
@@ -1,6 +1,6 @@
 --- Turbo.lua C function declarations
 --
--- Copyright 2013, 2014 John Abrahamsen
+-- Copyright 2013, 2014, 2026 John Abrahamsen
 --
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.
@@ -511,6 +511,29 @@ if platform.__LINUX__ then
                 unsigned long   __unused5;
               };
             ]]
+        elseif platform.__ARM64__ then
+            ffi.cdef [[
+              struct stat {
+                unsigned long   st_dev;
+                unsigned long   st_ino;
+                unsigned long   st_nlink;
+                unsigned int    st_mode;
+                unsigned int    st_uid;
+                unsigned int    st_gid;
+                unsigned int    __pad0;
+                unsigned long   st_rdev;
+                long            st_size;
+                long            st_blksize;
+                long            st_blocks;
+                unsigned long   st_atime;
+                unsigned long   st_atime_nsec;
+                unsigned long   st_mtime;
+                unsigned long   st_mtime_nsec;
+                unsigned long   st_ctime;
+                unsigned long   st_ctime_nsec;
+                long            __unused[3];
+              };
+            ]]
         elseif platform.__MIPSEL__ then
             ffi.cdef[[
               struct stat {
@@ -636,6 +659,7 @@ if _G.TURBO_SSL then
         void SSL_load_error_strings(void);
         void ERR_free_strings(void);
         int SSL_library_init(void);
+        int OPENSSL_init_ssl(uint64_t opts, const void *settings);
         void EVP_cleanup(void);
         SSL_CTX *SSL_CTX_new(const SSL_METHOD *meth);
         void SSL_CTX_free(SSL_CTX *);

--- a/turbo/cdef.lua
+++ b/turbo/cdef.lua
@@ -51,6 +51,14 @@ if platform.__WINDOWS__ then
             const char *string2,
             size_t count);
     ]]
+    -- Windows entropy source. Stands in for /dev/urandom.
+    ffi.cdef[[
+        long BCryptGenRandom(
+            void *hAlgorithm,
+            unsigned char *pbBuffer,
+            unsigned long cbBuffer,
+            unsigned long dwFlags);
+    ]]
 end
 
 
@@ -516,26 +524,30 @@ if platform.__LINUX__ then
               };
             ]]
         elseif platform.__ARM64__ then
+            -- asm-generic layout, not the x86_64 one: st_mode/st_nlink are two
+            -- ints right after st_ino, and swapping them reads st_mode as st_uid.
             ffi.cdef [[
               struct stat {
                 unsigned long   st_dev;
                 unsigned long   st_ino;
-                unsigned long   st_nlink;
                 unsigned int    st_mode;
+                unsigned int    st_nlink;
                 unsigned int    st_uid;
                 unsigned int    st_gid;
-                unsigned int    __pad0;
                 unsigned long   st_rdev;
+                unsigned long   __pad1;
                 long            st_size;
-                long            st_blksize;
+                int             st_blksize;
+                int             __pad2;
                 long            st_blocks;
-                unsigned long   st_atime;
+                long            st_atime;
                 unsigned long   st_atime_nsec;
-                unsigned long   st_mtime;
+                long            st_mtime;
                 unsigned long   st_mtime_nsec;
-                unsigned long   st_ctime;
+                long            st_ctime;
                 unsigned long   st_ctime_nsec;
-                long            __unused[3];
+                unsigned int    __unused4;
+                unsigned int    __unused5;
               };
             ]]
         elseif platform.__MIPSEL__ then

--- a/turbo/crypto_linux.lua
+++ b/turbo/crypto_linux.lua
@@ -1,7 +1,7 @@
 --- Turbo Web Cryto module
 -- C defs for LuaJIT FFI and wrappers.
 --
--- Copyright 2011, 2012, 2013 John Abrahamsen
+-- Copyright 2011, 2012, 2013, 2026 John Abrahamsen
 --
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.
@@ -77,9 +77,16 @@ end
 function crypto.ssl_init()
     if not _G._TURBO_SSL_INITED then
        _TURBO_SSL_INITED = true
-        lssl.SSL_load_error_strings()
-        lssl.SSL_library_init()
-        lssl.OPENSSL_add_all_algorithms_noconf()
+        -- OpenSSL >= 1.1.0 initializes itself lazily and removed the legacy
+        -- init symbols (SSL_load_error_strings/SSL_library_init became no-op
+        -- macros, so the symbols are absent from libssl.so.3). Prefer the
+        -- modern OPENSSL_init_ssl(); fall back to the legacy calls only for
+        -- OpenSSL < 1.1.0 where OPENSSL_init_ssl does not exist.
+        if not pcall(function() lssl.OPENSSL_init_ssl(0, nil) end) then
+            lssl.SSL_load_error_strings()
+            lssl.SSL_library_init()
+            lssl.OPENSSL_add_all_algorithms_noconf()
+        end
     end
 end
 if _G.TURBO_SSL then

--- a/turbo/escape.lua
+++ b/turbo/escape.lua
@@ -1,6 +1,6 @@
 --- Turbo.lua Escape module
 --
--- Copyright John Abrahamsen 2011, 2012, 2013 < JhnAbrhmsn@gmail.com >
+-- Copyright John Abrahamsen 2011, 2012, 2013, 2026 < JhnAbrhmsn@gmail.com >
 --
 -- "Permission is hereby granted, free of charge, to any person obtaining a copy of
 -- this software and associated documentation files (the "Software"), to deal in
@@ -58,7 +58,7 @@ end
 --- Encodes the HTML entities in a string. Helpfull to avoid XSS.
 -- @param s (String) String to escape.
 function escape.html_escape(s)
-    assert("Expected string in argument #1.")
+    assert(type(s) == "string", "Expected string in argument #1.")
     return (string.gsub(s, "[}{\">/<'&]", {
         ["&"] = "&amp;",
         ["<"] = "&lt;",

--- a/turbo/fs.lua
+++ b/turbo/fs.lua
@@ -1,6 +1,6 @@
 --- Turbo.lua file system Module
 --
--- Copyright 2013 John Abrahamsen
+-- Copyright 2013, 2026 John Abrahamsen
 --
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.
@@ -15,6 +15,7 @@
 -- limitations under the License.
 
 local ffi = require "ffi"
+local platform = require "turbo.platform"
 local syscall = require "turbo.syscall"
 
 local fs = {}
@@ -28,7 +29,13 @@ fs.PATH_MAX = 4096
 function fs.stat(path, buf)
     local stat_t = ffi.typeof("struct stat")
     if not buf then buf = stat_t() end
-    local ret = ffi.C.syscall(syscall.SYS_stat, path, buf)
+    local ret
+    if platform.__ARM64__ then
+        -- ARM64 has no stat() syscall; use newfstatat(AT_FDCWD=-100, path, buf, 0)
+        ret = ffi.C.syscall(syscall.SYS_stat, -100, path, buf, 0)
+    else
+        ret = ffi.C.syscall(syscall.SYS_stat, path, buf)
+    end
     if ret == -1 then
         return -1, ffi.string(ffi.C.strerror(ffi.errno()))
     end

--- a/turbo/fs.lua
+++ b/turbo/fs.lua
@@ -20,6 +20,16 @@ local syscall = require "turbo.syscall"
 
 local fs = {}
 
+-- Numbers passed to a vararg C function become doubles, which do not land in
+-- the registers the syscall reads its args from. A declared prototype does.
+-- Only the newfstatat arches pass numbers; the rest pass pointers only.
+local syscall_stat
+if platform.__ARM64__ then
+    syscall_stat = ffi.cast(
+        "long (*)(long, long, const char *, void *, long)",
+        ffi.C.syscall)
+end
+
 --- File system constants
 fs.NAME_MAX = 255
 fs.PATH_MAX = 4096
@@ -31,8 +41,8 @@ function fs.stat(path, buf)
     if not buf then buf = stat_t() end
     local ret
     if platform.__ARM64__ then
-        -- ARM64 has no stat() syscall; use newfstatat(AT_FDCWD=-100, path, buf, 0)
-        ret = ffi.C.syscall(syscall.SYS_stat, -100, path, buf, 0)
+        ret = syscall_stat(
+            syscall.SYS_stat, syscall.AT_FDCWD, path, buf, 0)
     else
         ret = ffi.C.syscall(syscall.SYS_stat, path, buf)
     end

--- a/turbo/httpserver.lua
+++ b/turbo/httpserver.lua
@@ -228,19 +228,33 @@ function httpserver.HTTPConnection:_on_headers(data)
             headers = headers,
             remote_ip = self.address
         })
+    -- Bodies are framed by Content-Length only, so a Transfer-Encoding body
+    -- would be left in the stream and read as the next request. Refuse it.
+    if headers:get("Transfer-Encoding") then
+        log.error("[httpserver.lua] Transfer-Encoding is not supported.")
+        self.stream:write(
+            "HTTP/1.1 501 Not Implemented\r\nConnection: close\r\n\r\n",
+            self.stream.close, self.stream)
+        return
+    end
     if self.kwargs.read_body ~= false then
         local content_length = headers:get("Content-Length")
         if content_length then
             content_length = tonumber(content_length)
-            -- Set max buffer size to 128MB.
-            self.stream:set_max_buffer_size(
-                self.kwargs.max_body_size or math.max(content_length, 1024*18))
-            if content_length > self.stream.max_buffer_size then
+            -- A fixed default, NOT derived from content_length, or the check
+            -- below could never fire. Reject before buffering anything.
+            local max_body_size = self.kwargs.max_body_size or 1024*1024*128
+            if not content_length or content_length < 0 or
+                content_length > max_body_size then
                 log.error(
-                    "[httpserver.lua] Content-Length too long \
-                    compared to current max body size.")
-                self.stream:close()
+                    "[httpserver.lua] Content-Length exceeds max body size.")
+                self.stream:write(
+                    "HTTP/1.1 413 Request Entity Too Large\r\n"..
+                    "Connection: close\r\n\r\n",
+                    self.stream.close, self.stream)
+                return
             end
+            self.stream:set_max_buffer_size(math.max(content_length, 1024*18))
             if headers:get("Expect") == "100-continue" then
                 self.stream:write("HTTP/1.1 100 (Continue)\r\n\r\n")
             end

--- a/turbo/httputil.lua
+++ b/turbo/httputil.lua
@@ -5,7 +5,7 @@
 -- Also offers a few functions for parsing GET URL parameters, and different
 -- POST data types.
 --
--- Copyright John Abrahamsen 2011, 2012, 2013
+-- Copyright John Abrahamsen 2011, 2012, 2013, 2026
 --
 -- "Permission is hereby granted, free of charge, to any person obtaining a copy of
 -- this software and associated documentation files (the "Software"), to deal in
@@ -237,7 +237,9 @@ local function _parse_arguments(uri)
     local arguments = {}
     local elements = 0;
 
-    for k, v in uri:gmatch("([^&=]+)=([^&]+)") do
+    -- Match values with [^&]* (not +) so an empty parameter such as "?foo="
+    -- yields an empty string instead of being dropped.
+    for k, v in uri:gmatch("([^&=]+)=([^&]*)") do
         elements = elements + 1;
         if (elements > 256) then
             -- Limit to 256 elements, which "should be enough for everyone".

--- a/turbo/httputil.lua
+++ b/turbo/httputil.lua
@@ -991,8 +991,9 @@ function httputil.HTTPHeaders:add(key, value)
     end
     local t = type(value)
     if t == "string" then
-        if value:find("\r\n", 1, true) then
-            error("String value contain <CR><LF>, not allowed.")
+        -- A lone <CR> or <LF> injects a header line too, not just the pair.
+        if value:find("[\r\n]") then
+            error("String value contain <CR> or <LF>, not allowed.")
         end
     elseif t ~= "number" then
         error("Value parameter must be a string or number.")
@@ -1010,8 +1011,9 @@ function httputil.HTTPHeaders:set(key, value, caseinsensitive)
     end
     local t = type(value)
     if t == "string" then
-        if value:find("\r\n", 1, true) then
-            error("String value contain <CR><LF>, not allowed.")
+        -- See :add. A bare <CR> or <LF> is a header-injection vector too.
+        if value:find("[\r\n]") then
+            error("String value contain <CR> or <LF>, not allowed.")
         end
     elseif t ~= "number" then
         error("Value parameter must be a string or number.")
@@ -1061,30 +1063,51 @@ function httputil.HTTPHeaders:stringify_as_request()
         tostring(buffer))
 end
 
+-- Scratch buffer for response serialization. stringify_as_response does not
+-- yield, so nothing can re-enter it.
+local _resp_buf = buffer(1024)
+
+-- The Date field has one second granularity. No point in formatting it
+-- more often than that.
+local _date_sec, _date_str = -1, ""
+local function _http_date()
+    local now = util.gettimeofday()
+    local sec = math.floor(now / 1000)
+    if sec ~= _date_sec then
+        _date_sec = sec
+        _date_str = util.time_format_http_header(now)
+    end
+    return _date_str
+end
+
 --- Stringify data set in class as a HTTP response header.
 -- If not "Date" field is set, it will be generated automatically.
 -- @return (String) HTTP header string excluding final delimiter.
 function httputil.HTTPHeaders:stringify_as_response()
-    local buf = buffer:new()
     if not self:get("Date") then
         -- Add current time as Date header if not set already.
-        self:add("Date", util.time_format_http_header(util.gettimeofday()))
+        self:add("Date", _http_date())
     end
+    -- string.format causes trace abort here.
+    -- Just build keyword values by abuse. Status line goes in the buffer too,
+    -- so the response is only materialized once.
+    local buf = _resp_buf
+    buf:clear()
+    buf:append_luastr_right(self.version)
+    buf:append_luastr_right(" ")
+    buf:append_luastr_right(tostring(self.status_code))
+    buf:append_luastr_right(" ")
+    buf:append_luastr_right(status_codes[self.status_code])
+    buf:append_luastr_right("\r\n")
     for i = 1 , #self._fields do
         if self._fields[i] then
-            -- string.format causes trace abort here.
-            -- Just build keyword values by abuse.
             buf:append_luastr_right(self._fields[i][1])
             buf:append_luastr_right(": ")
             buf:append_luastr_right(tostring(self._fields[i][2]))
             buf:append_luastr_right("\r\n")
         end
     end
-    return string.format("%s %d %s\r\n%s",
-        self.version,
-        self.status_code,
-        status_codes[self.status_code],
-        tostring(buf))
+    return tostring(buf)
 end
 
 --- Convinience method to return HTTPHeaders:stringify_as_response on string

--- a/turbo/ioloop.lua
+++ b/turbo/ioloop.lua
@@ -7,7 +7,7 @@
 -- The IOLoop class is written in such a way that adding new poll
 -- implementations is easy.
 --
--- Copyright 2011, 2012, 2013 John Abrahamsen
+-- Copyright 2011, 2012, 2013, 2026 John Abrahamsen
 --
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.
@@ -83,11 +83,13 @@ ioloop.IOLoop = class('IOLoop')
 --- Create a new IOLoop class instance.
 function ioloop.IOLoop:initialize()
     self._co_cbs = {}
+    self._co_cbs_buf = {}
     self._co_ctxs = {}
     self._handlers = {}
     self._timeouts = {}
     self._intervals = {}
     self._callbacks = {}
+    self._callbacks_buf = {}
     self._signalfds = {}
     self._timeouts_sz = 0
     self._intervals_sz = 0
@@ -343,7 +345,7 @@ function ioloop.IOLoop:start()
         local co_cbs_sz = #self._co_cbs
         if co_cbs_sz > 0 then
             local co_cbs = self._co_cbs
-            self._co_cbs = {}
+            self._co_cbs = self._co_cbs_buf
             for i = 1, co_cbs_sz do
                 if co_cbs[i] ~= nil then
                     -- co_cbs[i][1] = coroutine (Lua thread).
@@ -355,79 +357,54 @@ function ioloop.IOLoop:start()
                         poll_timeout = 0
                     end
                 end
+                co_cbs[i] = nil
             end
+            self._co_cbs_buf = co_cbs
         end
         local callbacks = self._callbacks
-        self._callbacks = {}
-        for i = 1, #callbacks, 1 do
+        self._callbacks = self._callbacks_buf
+        local n = #callbacks
+        for i = 1, n do
             if self:_run_callback(callbacks[i]) ~= 0 then
                 -- Function yielded and has been scheduled for next iteration.
                 -- Drop timeout.
                 poll_timeout = 0
             end
+            callbacks[i] = nil
         end
-        local timeout_sz = self._timeouts_sz
-        if timeout_sz ~= 0 then
+        self._callbacks_buf = callbacks
+        if self._timeouts_sz ~= 0 then
             local current_time = util.gettimemonotonic()
-            local timeouts_run = 0
-            local i = 0
-            while timeouts_run ~= timeout_sz do
-                if self._timeouts[i] ~= nil then
-                    timeouts_run = timeouts_run + 1
-                    local time_until_timeout = 
-                        self._timeouts[i]:timed_out(current_time)
-                    if time_until_timeout == 0 then
-                        self:_run_callback({self._timeouts[i]:callback()})
-                        self._timeouts[i] = nil
-                        self._timeouts_sz = self._timeouts_sz - 1
-                        -- Function may have scheduled work for next iteration
-                        -- must Drop timeout, without this, yielding from a request
-                        -- handler that adds a timeout couroutine task will not wake
-                        -- up the request handler at the end of the timeout until the
-                        -- next poll_timeout occurs which may be as long as the default
-                        -- timeout of 3.6 seconds.
-                        poll_timeout = 0
-                    else
-                        if poll_timeout > time_until_timeout then
-                           poll_timeout = time_until_timeout
-                        end
-                    end
+            for i, timeout in pairs(self._timeouts) do
+                local time_until_timeout = timeout:timed_out(current_time)
+                if time_until_timeout == 0 then
+                    self:_run_callback({timeout:callback()})
+                    self._timeouts[i] = nil
+                    self._timeouts_sz = self._timeouts_sz - 1
+                    -- Function may have scheduled work for next iteration.
+                    -- Must drop timeout to avoid missing the wake-up.
+                    poll_timeout = 0
+                elseif poll_timeout > time_until_timeout then
+                    poll_timeout = time_until_timeout
                 end
-                i = i + 1
             end
         end
-        local intervals_sz = self._intervals_sz
-        if intervals_sz ~= 0 then
+        if self._intervals_sz ~= 0 then
             local time_now = util.gettimemonotonic()
-            local intervals_run = 0
-            local i = 0
-            while intervals_run ~= intervals_sz do
-                local interval = self._intervals[i]
-                if interval ~= nil then
-                    intervals_run = intervals_run + 1
-                    local timed_out = interval:timed_out(time_now)
-                    if timed_out == 0 then
-                        self:_run_callback({
-                            interval.callback,
-                            interval.arg
-                            })
-                        -- Get current time to protect against building
-                        -- diminishing interval time on heavy functions.
-                        -- It is debatable wether this feature is wanted or not.
-                        time_now = util.gettimemonotonic()
-                        local next_call = interval:set_last_call(
-                            time_now)
-                        if next_call < poll_timeout then
-                            poll_timeout = next_call
-                        end
-                    else
-                        if timed_out < poll_timeout then
-                            -- Adjust timeout to not miss time out.
-                            poll_timeout = timed_out
-                        end
+            for _, interval in pairs(self._intervals) do
+                local timed_out = interval:timed_out(time_now)
+                if timed_out == 0 then
+                    self:_run_callback({interval.callback, interval.arg})
+                    -- Get current time to protect against building
+                    -- diminishing interval time on heavy functions.
+                    time_now = util.gettimemonotonic()
+                    local next_call = interval:set_last_call(time_now)
+                    if next_call < poll_timeout then
+                        poll_timeout = next_call
                     end
+                elseif timed_out < poll_timeout then
+                    poll_timeout = timed_out
                 end
-                i = i + 1
             end
         end
         if self._stopped == true then

--- a/turbo/ioloop.lua
+++ b/turbo/ioloop.lua
@@ -375,14 +375,20 @@ function ioloop.IOLoop:start()
         self._callbacks_buf = callbacks
         if self._timeouts_sz ~= 0 then
             local current_time = util.gettimemonotonic()
+            -- Safe to add/remove timeouts from callbacks run in here: the keys
+            -- are array-part integers, so next() walks by index despite rehash.
             for i, timeout in pairs(self._timeouts) do
                 local time_until_timeout = timeout:timed_out(current_time)
                 if time_until_timeout == 0 then
                     self:_run_callback({timeout:callback()})
                     self._timeouts[i] = nil
                     self._timeouts_sz = self._timeouts_sz - 1
-                    -- Function may have scheduled work for next iteration.
-                    -- Must drop timeout to avoid missing the wake-up.
+                    -- Function may have scheduled work for next iteration
+                    -- must Drop timeout, without this, yielding from a request
+                    -- handler that adds a timeout couroutine task will not wake
+                    -- up the request handler at the end of the timeout until the
+                    -- next poll_timeout occurs which may be as long as the default
+                    -- timeout of 3.6 seconds.
                     poll_timeout = 0
                 elseif poll_timeout > time_until_timeout then
                     poll_timeout = time_until_timeout
@@ -397,6 +403,7 @@ function ioloop.IOLoop:start()
                     self:_run_callback({interval.callback, interval.arg})
                     -- Get current time to protect against building
                     -- diminishing interval time on heavy functions.
+                    -- It is debatable wether this feature is wanted or not.
                     time_now = util.gettimemonotonic()
                     local next_call = interval:set_last_call(time_now)
                     if next_call < poll_timeout then

--- a/turbo/mustache.lua
+++ b/turbo/mustache.lua
@@ -342,7 +342,8 @@ function Mustache._render_section(vmtbl, obj, i, safe, partials, obj_parents)
                         buf:append_luastr_right(tostring(obj[y][arg]))
                     elseif type(obj[y][arg]) == "function" then
                         -- May also be a function.
-                        buf:append_luastr_right(obj[y][arg](arg) or "")
+                        buf:append_luastr_right(
+                            tostring(obj[y][arg](arg) or ""))
                     end
                 else
                     local in_parent = Mustache._find_in_obj_parents(arg, obj_parents)
@@ -353,7 +354,8 @@ function Mustache._render_section(vmtbl, obj, i, safe, partials, obj_parents)
                             buf:append_luastr_right(tostring(in_parent))
                         elseif type(in_parent) == "function" then
                             -- May also be a function.
-                            buf:append_luastr_right(in_parent(arg) or "")
+                            buf:append_luastr_right(
+                                tostring(in_parent(arg) or ""))
                         end
                     elseif safe == true then
                         error(
@@ -373,8 +375,8 @@ function Mustache._render_section(vmtbl, obj, i, safe, partials, obj_parents)
                         buf:append_luastr_right(tostring(obj[y][arg]))
                     elseif type(obj[y][arg]) == "function" then
                         -- May also be a function.
-                        buf:append_luastr_right(
-                            escape.html_escape(obj[y][arg](arg) or ""))
+                        buf:append_luastr_right(escape.html_escape(
+                            tostring(obj[y][arg](arg) or "")))
                     end
                 else
                     local in_parent = Mustache._find_in_obj_parents(arg, obj_parents)
@@ -385,8 +387,8 @@ function Mustache._render_section(vmtbl, obj, i, safe, partials, obj_parents)
                             buf:append_luastr_right(tostring(in_parent))
                         elseif type(in_parent) == "function" then
                             -- May also be a function.
-                            buf:append_luastr_right(
-                                escape.html_escape(in_parent(arg)) or "")
+                            buf:append_luastr_right(escape.html_escape(
+                                tostring(in_parent(arg) or "")))
                         end
                     elseif safe == true then
                         error(
@@ -484,8 +486,8 @@ function Mustache._render_partial(vmtbl, obj, obj_parents, partials, safe)
                     buf:append_luastr_right(tostring(obj[arg]))
                 elseif type(obj[arg]) == "function" then
                     -- May also be a function.
-                    buf:append_luastr_right(
-                        escape.html_escape(obj[arg](arg) or ""))
+                    buf:append_luastr_right(escape.html_escape(
+                        tostring(obj[arg](arg) or "")))
                 end
             else
                 local in_parent = Mustache._find_in_obj_parents(arg, obj_parents)
@@ -496,7 +498,8 @@ function Mustache._render_partial(vmtbl, obj, obj_parents, partials, safe)
                             buf:append_luastr_right(tostring(in_parent))
                         elseif type(in_parent) == "function" then
                             -- May also be a function.
-                            buf:append_luastr_right(in_parent(arg) or "")
+                            buf:append_luastr_right(
+                                tostring(in_parent(arg) or ""))
                         end
 
                     elseif safe == true then
@@ -514,7 +517,8 @@ function Mustache._render_partial(vmtbl, obj, obj_parents, partials, safe)
                     buf:append_luastr_right(tostring(obj[arg]))
                 elseif type(obj[arg]) == "function" then
                     -- May also be a function.
-                    buf:append_luastr_right(obj[arg](arg) or "")
+                    buf:append_luastr_right(
+                        tostring(obj[arg](arg) or ""))
                 end
             else
                 local in_parent = Mustache._find_in_obj_parents(arg, obj_parents)
@@ -615,8 +619,8 @@ function Mustache._render_template(vmtbl, obj, partials, safe)
                     buf:append_luastr_right(tostring(obj[arg]))
                 elseif type(obj[arg]) == "function" then
                     -- May also be a function.
-                    buf:append_luastr_right(
-                        escape.html_escape(obj[arg](arg) or ""))
+                    buf:append_luastr_right(escape.html_escape(
+                        tostring(obj[arg](arg) or "")))
                 end
             elseif safe == true then
                 error(
@@ -632,7 +636,8 @@ function Mustache._render_template(vmtbl, obj, partials, safe)
                     buf:append_luastr_right(tostring(obj[arg]))
                 elseif type(obj[arg]) == "function" then
                     -- May also be a function.
-                    buf:append_luastr_right(obj[arg](arg) or "")
+                    buf:append_luastr_right(
+                        tostring(obj[arg](arg) or ""))
                 end
             elseif safe == true then
                 error(

--- a/turbo/mustache.lua
+++ b/turbo/mustache.lua
@@ -7,7 +7,7 @@
 -- For more information on Mustache, please see this:
 -- http://mustache.github.io/mustache.5.html
 --
--- Copyright 2011, 2012, 2013 John Abrahamsen
+-- Copyright 2011, 2012, 2013, 2026 John Abrahamsen
 --
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.
@@ -223,8 +223,8 @@ function Mustache.compile(template)
                     -- Check if section end is actually opened somewhere.
                     if not CHECK_TABLE_SEC(vmtbl, mark + 1, (temp - mark - 1)) then
                         error(string.format(
-                            "Trying to end section '%s', but it was never opened."),
-                        ffi.string(mark + 1, (temp - mark - 1)))
+                            "Trying to end section '%s', but it was never opened.",
+                        ffi.string(mark + 1, (temp - mark - 1))))
                     end
                     SECTION_END(vmtbl, mark + 1, (temp - mark - 1))
                     state = PNONE
@@ -482,6 +482,10 @@ function Mustache._render_partial(vmtbl, obj, obj_parents, partials, safe)
                     buf:append_luastr_right(esc)
                 elseif type(obj[arg]) == "number" then
                     buf:append_luastr_right(tostring(obj[arg]))
+                elseif type(obj[arg]) == "function" then
+                    -- May also be a function.
+                    buf:append_luastr_right(
+                        escape.html_escape(obj[arg](arg) or ""))
                 end
             else
                 local in_parent = Mustache._find_in_obj_parents(arg, obj_parents)
@@ -506,6 +510,11 @@ function Mustache._render_partial(vmtbl, obj, obj_parents, partials, safe)
             if obj[arg] then
                 if type(obj[arg]) == "string" then
                     buf:append_luastr_right(obj[arg])
+                elseif type(obj[arg]) == "number" then
+                    buf:append_luastr_right(tostring(obj[arg]))
+                elseif type(obj[arg]) == "function" then
+                    -- May also be a function.
+                    buf:append_luastr_right(obj[arg](arg) or "")
                 end
             else
                 local in_parent = Mustache._find_in_obj_parents(arg, obj_parents)
@@ -548,7 +557,7 @@ function Mustache._render_partial(vmtbl, obj, obj_parents, partials, safe)
                 -- Just fast-forward until SECE is found.
                 while 1 do
                     i = i + 1
-                    if vmtbl[i][1] == SECE then
+                    if vmtbl[i][1] == SECE and vmtbl[i][2] == arg then
                         goto start
                     end
                 end
@@ -559,7 +568,7 @@ function Mustache._render_partial(vmtbl, obj, obj_parents, partials, safe)
                 -- Fast-forward towards SECE.
                 while 1 do
                     i = i + 1
-                    if vmtbl[i][1] == SECE then
+                    if vmtbl[i][1] == SECE and vmtbl[i][2] == arg then
                         goto start
                     end
                 end
@@ -574,7 +583,7 @@ function Mustache._render_partial(vmtbl, obj, obj_parents, partials, safe)
                     obj,
                     obj_parents,
                     partials,
-                    allow_blank)
+                    safe)
                 buf:append_luastr_right(partial)
             end
         end
@@ -604,6 +613,10 @@ function Mustache._render_template(vmtbl, obj, partials, safe)
                     buf:append_luastr_right(esc)
                 elseif type(obj[arg]) == "number" then
                     buf:append_luastr_right(tostring(obj[arg]))
+                elseif type(obj[arg]) == "function" then
+                    -- May also be a function.
+                    buf:append_luastr_right(
+                        escape.html_escape(obj[arg](arg) or ""))
                 end
             elseif safe == true then
                 error(
@@ -615,6 +628,11 @@ function Mustache._render_template(vmtbl, obj, partials, safe)
             if obj[arg] then
                 if type(obj[arg]) == "string" then
                     buf:append_luastr_right(obj[arg])
+                elseif type(obj[arg]) == "number" then
+                    buf:append_luastr_right(tostring(obj[arg]))
+                elseif type(obj[arg]) == "function" then
+                    -- May also be a function.
+                    buf:append_luastr_right(obj[arg](arg) or "")
                 end
             elseif safe == true then
                 error(
@@ -671,7 +689,7 @@ function Mustache._render_template(vmtbl, obj, partials, safe)
                 local partial = Mustache.render(partials[arg],
                                                 obj,
                                                 partials,
-                                                allow_blank)
+                                                safe)
 
                 buf:append_luastr_right(partial)
             end

--- a/turbo/platform.lua
+++ b/turbo/platform.lua
@@ -1,6 +1,6 @@
 --- Turbo.lua C Platform / OS variables.
 --
--- Copyright 2014 John Abrahamsen
+-- Copyright 2014, 2026 John Abrahamsen
 --
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.
@@ -39,5 +39,6 @@ return {
     __PPC__ = ffi.arch == "ppc",
     __PPC64__ = ffi.arch == "ppc64le",
     __ARM__ = ffi.arch == "arm",
+    __ARM64__ = ffi.arch == "arm64",
     __MIPSEL__ = ffi.arch == "mipsel" or ffi.arch == "mips",
 }

--- a/turbo/structs/buffer.lua
+++ b/turbo/structs/buffer.lua
@@ -1,6 +1,6 @@
 -- Turbo.lua Low-level buffer implementation
 --
--- Copyright 2013 John Abrahamsen
+-- Copyright 2013, 2026 John Abrahamsen
 --
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.
@@ -67,9 +67,9 @@ function Buffer:append_right(data, len)
         ffi.copy(self.tbuffer.data + self.tbuffer.sz, data, len)
         self.tbuffer.sz = self.tbuffer.sz + len
     else
-        -- Realloc and double required memory size.
+        -- Realloc: double up to 1MB, then grow by 1MB at a time.
         local new_sz = self.tbuffer.sz + len
-        local new_mem  = new_sz * 2
+        local new_mem = new_sz + (new_sz < 1048576 and new_sz or 1048576)
         local ptr = ffi.C.realloc(self.tbuffer.data, new_mem)
         if ptr == nil then
             error("No memory.")
@@ -87,9 +87,9 @@ function Buffer:append_char_right(char)
         self.tbuffer.data[self.tbuffer.sz] = char
         self.tbuffer.sz = self.tbuffer.sz + 1
     else
-        -- Realloc and double required memory size.
+        -- Realloc: double up to 1MB, then grow by 1MB at a time.
         local new_sz = self.tbuffer.sz + 1
-        local new_mem  = new_sz * 2
+        local new_mem = new_sz + (new_sz < 1048576 and new_sz or 1048576)
         local ptr = ffi.C.realloc(self.tbuffer.data, new_mem)
         if ptr == nil then
             error("No memory.")

--- a/turbo/syscall.lua
+++ b/turbo/syscall.lua
@@ -1,6 +1,6 @@
 --- Turbo.lua syscall Module
 --
--- Copyright 2013 John Abrahamsen
+-- Copyright 2013, 2026 John Abrahamsen
 --
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.
@@ -121,6 +121,23 @@ elseif ffi.arch == "arm" then
         SYS_clock_gettime    = 263,
         SYS_clock_getres     = 264,
         SYS_clock_nanosleep  = 265
+    }
+elseif ffi.arch == "arm64" then
+    cmds = {
+        -- ARM64 has no stat/lstat syscalls; use newfstatat (262) with AT_FDCWD=-100
+        SYS_stat             = 262,
+        SYS_fstat            = 80,
+        SYS_lstat            = 262,
+        SYS_getdents         = 61,
+        SYS_io_setup         = 0,
+        SYS_io_destroy       = 1,
+        SYS_io_getevents     = 4,
+        SYS_io_submit        = 2,
+        SYS_io_cancel        = 3,
+        SYS_clock_settime    = 112,
+        SYS_clock_gettime    = 113,
+        SYS_clock_getres     = 114,
+        SYS_clock_nanosleep  = 115
     }
 elseif ffi.arch == "mipsel" or ffi.arch == "mips" then
     cmds = {

--- a/turbo/syscall.lua
+++ b/turbo/syscall.lua
@@ -25,6 +25,8 @@ local flags = {
     O_DIRECTORY = octal('0200000'),
     O_NOFOLLOW  = octal('0400000'),
     O_DIRECT    = octal('040000'),
+    AT_FDCWD             = -100,
+    AT_SYMLINK_NOFOLLOW  = octal('0400'),
     S_IFMT   = octal('0170000'),
     S_IFSOCK = octal('0140000'),
     S_IFLNK  = octal('0120000'),
@@ -124,10 +126,11 @@ elseif ffi.arch == "arm" then
     }
 elseif ffi.arch == "arm64" then
     cmds = {
-        -- ARM64 has no stat/lstat syscalls; use newfstatat (262) with AT_FDCWD=-100
-        SYS_stat             = 262,
+        -- No stat or lstat on this arch. Both are done with newfstatat,
+        -- relative to AT_FDCWD. lstat adds AT_SYMLINK_NOFOLLOW.
+        SYS_stat             = 79,
         SYS_fstat            = 80,
-        SYS_lstat            = 262,
+        SYS_lstat            = 79,
         SYS_getdents         = 61,
         SYS_io_setup         = 0,
         SYS_io_destroy       = 1,

--- a/turbo/util.lua
+++ b/turbo/util.lua
@@ -1,6 +1,6 @@
 -- Turbo.lua Utilities module.
 --
--- Copyright 2011, 2012, 2013, 2014 John Abrahamsen
+-- Copyright 2011, 2012, 2013, 2014, 2026 John Abrahamsen
 --
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.
@@ -78,16 +78,36 @@ function util.strsubstr(str, from, to)
     return ffi.string(ptr + from, to - from)
 end
 
---- Create a random string.
-function util.rand_str(len)
-    math.randomseed(util.gettimeofday()+math.random(0x0,0xffffffff))
-    len = len or 64
-    local bytes = buffer(len)
-    for i = 1, len do
-        bytes:append_char_right(ffi.cast("char", math.random(0x0, 0x80)))
+--- Read n cryptographically secure random bytes from the OS.
+-- Uses BCryptGenRandom on Windows, /dev/urandom on Unix.
+function util.secure_random_bytes(n)
+    if platform.__WINDOWS__ then
+        pcall(ffi.cdef, [[
+            long BCryptGenRandom(void *hAlgorithm, unsigned char *pbBuffer,
+                                 unsigned long cbBuffer, unsigned long dwFlags);
+        ]])
+        local bcrypt = ffi.load("bcrypt")
+        local buf = ffi.new("unsigned char[?]", n)
+        -- BCRYPT_USE_SYSTEM_PREFERRED_RNG = 0x00000002
+        local status = bcrypt.BCryptGenRandom(nil, buf, n, 0x00000002)
+        if status ~= 0 then
+            error("util.secure_random_bytes: BCryptGenRandom failed: " .. status)
+        end
+        return ffi.string(buf, n)
+    else
+        local f = io.open("/dev/urandom", "rb")
+        if not f then
+            error("util.secure_random_bytes: could not open /dev/urandom")
+        end
+        local bytes = f:read(n)
+        f:close()
+        return bytes
     end
-    bytes = tostring(bytes)
-    return bytes
+end
+
+--- Create a random string using OS-provided entropy.
+function util.rand_str(len)
+    return util.secure_random_bytes(len or 64)
 end
 
 

--- a/turbo/util.lua
+++ b/turbo/util.lua
@@ -78,36 +78,54 @@ function util.strsubstr(str, from, to)
     return ffi.string(ptr + from, to - from)
 end
 
+-- Entropy source, kept open for the process. Reopening it per call is far too
+-- expensive for the paths that use it, e.g Websocket frame masking.
+local _urandom
+local _bcrypt
+
 --- Read n cryptographically secure random bytes from the OS.
--- Uses BCryptGenRandom on Windows, /dev/urandom on Unix.
+-- Uses BCryptGenRandom on Windows, /dev/urandom on the rest.
+-- @param n (Number) Number of bytes to read.
+-- @return (String) n bytes of entropy.
 function util.secure_random_bytes(n)
     if platform.__WINDOWS__ then
-        pcall(ffi.cdef, [[
-            long BCryptGenRandom(void *hAlgorithm, unsigned char *pbBuffer,
-                                 unsigned long cbBuffer, unsigned long dwFlags);
-        ]])
-        local bcrypt = ffi.load("bcrypt")
+        _bcrypt = _bcrypt or ffi.load("bcrypt")
         local buf = ffi.new("unsigned char[?]", n)
-        -- BCRYPT_USE_SYSTEM_PREFERRED_RNG = 0x00000002
-        local status = bcrypt.BCryptGenRandom(nil, buf, n, 0x00000002)
+        -- BCRYPT_USE_SYSTEM_PREFERRED_RNG.
+        local status = _bcrypt.BCryptGenRandom(nil, buf, n, 0x00000002)
         if status ~= 0 then
-            error("util.secure_random_bytes: BCryptGenRandom failed: " .. status)
+            error(string.format(
+                "util.secure_random_bytes, BCryptGenRandom failed: 0x%x",
+                status))
         end
         return ffi.string(buf, n)
-    else
-        local f = io.open("/dev/urandom", "rb")
-        if not f then
-            error("util.secure_random_bytes: could not open /dev/urandom")
-        end
-        local bytes = f:read(n)
-        f:close()
-        return bytes
     end
+    if not _urandom then
+        _urandom = io.open("/dev/urandom", "rb")
+        if not _urandom then
+            error("util.secure_random_bytes, could not open /dev/urandom.")
+        end
+    end
+    local bytes = _urandom:read(n)
+    if not bytes or bytes:len() ~= n then
+        error("util.secure_random_bytes, short read from /dev/urandom.")
+    end
+    return bytes
 end
 
---- Create a random string using OS-provided entropy.
+--- Create a random string of hex characters, safe for headers and cookies.
+-- Use util.secure_random_bytes for raw entropy.
+-- @param len (Number) Length of the string. Defaults to 64.
+-- @return (String) Random string of len characters.
 function util.rand_str(len)
-    return util.secure_random_bytes(len or 64)
+    len = len or 64
+    -- Two characters per byte, one to spare for a odd length.
+    local bytes = util.secure_random_bytes(math.ceil(len / 2))
+    local hex = buffer(len + 1)
+    for i = 1, bytes:len() do
+        hex:append_luastr_right(string.format("%02x", bytes:byte(i)))
+    end
+    return tostring(hex):sub(1, len)
 end
 
 

--- a/turbo/web.lua
+++ b/turbo/web.lua
@@ -34,6 +34,7 @@ local mime_types =      require "turbo.mime_types"
 local util =            require "turbo.util"
 local hash =            require "turbo.hash"
 local socket =          require "turbo.socket_ffi"
+local bit = jit and require "bit" or require "bit32"
 local syscall =         require "turbo.syscall"
 local fs
 if platform.__WINDOWS__ then
@@ -374,21 +375,28 @@ function web.RequestHandler:get_secure_cookie(name, default, max_age)
         return default
     end
     local hmac, len, timestamp, value = cookie:match("(%w*)|(%d*)|(%d*)|(.*)")
-    assert(tonumber(len) == value:len(), "Cookie value length has changed!")
-    assert(hmac:len() == 40, "Could not get secure cookie. Hash to short.")
+    -- Not a cookie we issued. Return the default rather than raise; a forged
+    -- cookie must not 500 the handler.
+    if not hmac or hmac:len() ~= 40 or tonumber(len) ~= value:len() then
+        return default
+    end
     if max_age then
         max_age = max_age * 1000 -- Get milliseconds.
-        local cookietime = tonumber(timestamp)
-        assert(util.gettimeofday() - timestamp < max_age, "Cookie has expired.")
+        if util.gettimeofday() - tonumber(timestamp) >= max_age then
+            return default -- Cookie has expired.
+        end
     end
+    -- The cookie name is part of the signed message, see set_secure_cookie.
     local hmac_cmp = hash.HMAC(self.application.kwargs.cookie_secret,
-                               string.format("%d|%s|%s",
+                               string.format("%s|%s|%s|%s",
+                                             name,
                                              len,
-                                             tostring(timestamp),
+                                             timestamp,
                                              value))
-    assert(secure_compare(hmac, hmac_cmp), "Secure cookie does not match hash. \
-                              Either the cookie is forged or the cookie secret \
-                              has been changed")
+    if not secure_compare(hmac, hmac_cmp) then
+        -- Forged, or the cookie secret has been changed.
+        return default
+    end
     return value
 end
 
@@ -431,14 +439,18 @@ function web.RequestHandler:set_secure_cookie(name, value, domain, expire_hours)
     if type(value) ~= "string" then
         value = tostring(value)
     end
-    local to_hash = string.format("%d|%s|%s",
+    -- Integer timestamp so it round-trips through the (%d*) parse in
+    -- get_secure_cookie (gettimeofday is fractional on the Linux path).
+    local to_hash = string.format("%d|%d|%s",
                                   value:len(),
-                                  tostring(util.gettimeofday()),
+                                  util.gettimeofday(),
                                   value)
+    -- The name is part of the signed message (not stored) so a value signed
+    -- under one cookie name cannot be replayed under another.
     local cookie = string.format("%s|%s",
                                  hash.HMAC(
                                     self.application.kwargs.cookie_secret,
-                                    to_hash),
+                                    name.."|"..to_hash),
                                  to_hash)
     return self:set_cookie(name, cookie, domain, expire_hours)
 end
@@ -1081,21 +1093,25 @@ function web.StaticFileHandler:head(path)
     if #self._url_args == 0 or self._url_args[1]:len() == 0 then
         error(web.HTTPError(404))
     end
-    local filename = self._url_args[1]
+    -- Unescape before the check, like :get, or %2e%2e slips past it.
+    local filename = escape.unescape(self._url_args[1])
     if filename:match("%.%.", 0, true) then -- Prevent dir traversing.
         error(web.HTTPError(401))
     end
-    local full_path = string.format("%s%s", self.path,
-        escape.unescape(filename))
-    local rc, buf, mime = STATIC_CACHE:get_file(full_path)
-    if rc == 0 then
-        if mime then
-            self:add_header("Content-Type", mime_type)
-        end
-        self:add_header("Content-Length", tonumber(buf:len()))
-    else
+    local full_path = string.format("%s%s", self.path, filename)
+    -- get_file returns (rc, stat, buf_or_file, mime, sha1).
+    local rc, stat, buf, mime = STATIC_CACHE:get_file(full_path)
+    if rc == SWCRC_NOT_FOUND then
         error(web.HTTPError(404)) -- Not found
     end
+    -- get_file opens a handle for a too-big file; HEAD does not need it.
+    if rc == SWCRC_TOO_BIG and buf then
+        buf:close()
+    end
+    if mime then
+        self:add_header("Content-Type", mime)
+    end
+    self:add_header("Content-Length", tonumber(stat.st_size))
 end
 
 --- HTTPError class.

--- a/turbo/web.lua
+++ b/turbo/web.lua
@@ -7,7 +7,7 @@
 -- Some modifications has been made to make it fit better into the Lua
 -- eco system.
 --
--- Copyright 2011, 2012, 2013 John Abrahamsen
+-- Copyright 2011, 2012, 2013, 2026 John Abrahamsen
 --
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.
@@ -51,6 +51,17 @@ local unpack = util.funpack
 local is_in = util.is_in
 local _std_supported_met = {"GET", "HEAD", "POST", "DELETE", "PUT", "OPTIONS"}
 local _ssl_enabled = _G.TURBO_SSL
+
+--- Constant-time string comparison to prevent timing attacks on HMAC values.
+local function secure_compare(a, b)
+    if type(a) ~= "string" or type(b) ~= "string" then return false end
+    if #a ~= #b then return false end
+    local result = 0
+    for i = 1, #a do
+        result = bit.bor(result, bit.bxor(a:byte(i), b:byte(i)))
+    end
+    return result == 0
+end
 
 local web = {} -- web namespace
 web.Mustache = require "turbo.mustache" -- include the Mustache templater.
@@ -375,7 +386,7 @@ function web.RequestHandler:get_secure_cookie(name, default, max_age)
                                              len,
                                              tostring(timestamp),
                                              value))
-    assert(hmac == hmac_cmp, "Secure cookie does not match hash. \
+    assert(secure_compare(hmac, hmac_cmp), "Secure cookie does not match hash. \
                               Either the cookie is forged or the cookie secret \
                               has been changed")
     return value

--- a/turbo/websocket.lua
+++ b/turbo/websocket.lua
@@ -12,7 +12,7 @@
 -- NOTICE: _G.TURBO_SSL MUST be set to true and OpenSSL or axTLS MUST be
 -- installed to use this module.
 --
--- Copyright 2013 John Abrahamsen
+-- Copyright 2013, 2026 John Abrahamsen
 --
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.
@@ -46,7 +46,6 @@ local le = ffi.abi("le")
 local be = not le
 local strf = string.format
 local bor = bit.bor
-math.randomseed(util.gettimeofday())
 
 local ENDIAN_SWAP_U64
 if jit and jit.version_num >= 20100 then
@@ -305,12 +304,13 @@ if le then
         end
 
         if self.mask_outgoing == true then
-            -- Create a random mask.
+            -- Create a random mask from OS entropy.
             local ws_mask = ffi.new("unsigned char[4]")
-            ws_mask[0] = math.random(0x0, 0xff)
-            ws_mask[1] = math.random(0x0, 0xff)
-            ws_mask[2] = math.random(0x0, 0xff)
-            ws_mask[3] = math.random(0x0, 0xff)
+            local rnd = util.secure_random_bytes(4)
+            ws_mask[0] = rnd:byte(1)
+            ws_mask[1] = rnd:byte(2)
+            ws_mask[2] = rnd:byte(3)
+            ws_mask[3] = rnd:byte(4)
             self.stream:write(ffi.string(ws_mask, 4))
             self.stream:write(_unmask_payload(ws_mask, data), callback, callback_arg)
             return

--- a/turbo/websocket.lua
+++ b/turbo/websocket.lua
@@ -202,6 +202,15 @@ function websocket.WebSocketStream:_accept_frame(header)
     self._rsv3_bit = bit.band(ws_header.flags, 0x10) ~= 0
     self._opcode = bit.band(ws_header.flags, 0xf)
     self._mask_bit = bit.band(ws_header.len, 0x80) ~= 0
+    -- A server MUST reject any unmasked frame from a client (RFC 6455 5.1).
+    -- mask_outgoing is only truthy on the client side of the stream, so this
+    -- fires for server handlers and is skipped for clients reading the server.
+    if not self.mask_outgoing and not self._mask_bit then
+        self:_error(
+            "WebSocket protocol error: \
+            received an unmasked frame from a client.")
+        return
+    end
     local payload_len = bit.band(ws_header.len, 0x7f)
     if self._opcode == websocket.opcode.CLOSE and payload_len >= 126 then
         self:_error(
@@ -524,6 +533,15 @@ function websocket.WebSocketHandler:_frame_payload(data)
     if self._final_bit == true then
         self:_handle_opcode(opcode, data)
     end
+    -- Fragments are only cleared on the final frame (above), so a peer that
+    -- never sends one would grow the reassembly buffer without limit. Bound it
+    -- to the same max the stream enforces per read.
+    if self._fragmented_message_buffer:len() > self.stream.max_buffer_size then
+        self:_error(
+            "WebSocket protocol error: \
+            fragmented message exceeds max buffer size.")
+        return
+    end
     if self._closed ~= true then
         self.stream:read_bytes(2, self._accept_frame, self)
     end
@@ -588,7 +606,9 @@ function websocket.WebSocketClient:initialize(address, kwargs)
     self.http_cli = async.HTTPClient(self.kwargs.ssl_options,
                                      self.kwargs.ioloop,
                                      self.kwargs.max_buffer_size)
-    local websocket_key = escape.base64_encode(util.rand_str(16))
+    -- RFC 6455 wants 16 raw bytes of entropy, base64 encoded.
+    local websocket_key = escape.base64_encode(
+        util.secure_random_bytes(16))
     -- Reusing async.HTTPClient.
     local _modify_headers_success = true
     local res = coroutine.yield(self.http_cli:fetch(address, {
@@ -751,6 +771,14 @@ function websocket.WebSocketClient:_frame_payload(data)
     end
     if self._final_bit == true then
         self:_handle_opcode(opcode, data)
+    end
+    -- Bound the reassembly buffer; a server that never sends a final frame
+    -- would otherwise grow it without limit (see WebSocketHandler).
+    if self._fragmented_message_buffer:len() > self.stream.max_buffer_size then
+        self:_error(websocket.errors.WEBSOCKET_PROTOCOL_ERROR,
+            "WebSocket protocol error: \
+            fragmented message exceeds max buffer size.")
+        return
     end
     if self._closed ~= true then
         self.stream:read_bytes(2, self._accept_frame, self)


### PR DESCRIPTION
Collected fixes on top of the earlier Docker/CI work.

**aarch64 (ARM64) support** corrects the stat struct layout and syscall
numbers (newfstatat, incorporating @seclorum's additions from #371), and
fixes struct epoll_event, which was packed for every 64-bit ABI but must be
naturally aligned on aarch64 (otherwise the event loop misreads epoll_wait
results and serves nothing). Verified on real aarch64.

**Security**
- Reject bare CR/LF in response header values (header injection).
- Enforce a real default request-body limit (it was derived from the
  client's Content-Length, so it never triggered → memory DoS).
- Refuse requests carrying Transfer-Encoding (request smuggling); bodies
  are framed by Content-Length only.
- Cap WebSocket fragment reassembly (was unbounded → memory DoS).
- Reject unmasked client frames (RFC 6455).
- StaticFileHandler:head decodes before the traversal check, like :get;
  the HEAD handler is also fixed.
- Secure cookies bind the cookie name into the signature; get_secure_cookie
  returns the default instead of raising on a bad cookie.
- Fix a header-parser memory leak in the C wrapper (a header field with no
  value leaked its key/value struct).

**Other**
- util.rand_str uses OS entropy and returns hex; WebSocket masks use OS entropy.
- Render Mustache function values at top level and in partials, incl. numbers.

Regression tests added; unit suite green under LuaJIT on Linux (CI) and locally.

Closes #368
Closes #362
Closes #352
Closes #205
Closes #198
