### PR TITLE
Fix write hang, WebSocket dispatch, dead rockspec URLs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -54,4 +54,5 @@ CMD ["spec/security_spec.lua", \
      "spec/structs_spec.lua", \
      "spec/hash_spec.lua", \
      "spec/httputil_spec.lua", \
-     "spec/server_spec.lua"]
+     "spec/server_spec.lua", \
+     "spec/websocket_spec.lua"]

--- a/rockspecs/turbo-2.1-4.rockspec
+++ b/rockspecs/turbo-2.1-4.rockspec
@@ -2,7 +2,7 @@ package = "turbo"
 version = "2.1-4"
 supported_platforms = {"linux", "macosx"}
 source = {
-    url = "git://github.com/kernelsauce/turbo",
+    url = "git+https://github.com/kernelsauce/turbo.git",
     tag = "v2.1.4"
 }
 description = {

--- a/rockspecs/turbo-dev-1.rockspec
+++ b/rockspecs/turbo-dev-1.rockspec
@@ -2,7 +2,7 @@ package = "turbo"
 version = "dev-1"
 supported_platforms = {"linux"}
 source = {
-    url = "git://github.com/kernelsauce/turbo"
+    url = "git+https://github.com/kernelsauce/turbo.git"
 }
 description = {
     summary = "A networking suite for LuaJIT2 and Linux, optimized for performance.",

--- a/spec/iostream_spec.lua
+++ b/spec/iostream_spec.lua
@@ -573,5 +573,112 @@ describe("turbo.iostream Namespace", function()
             assert.truthy(streamed > 1)
         end)
 
+        -- Regression: a zero-length write_zero_copy buffer (e.g. serving a
+        -- zero-length static file) used to never complete, because send()/
+        -- SSL_write() legitimately return 0 for an empty buffer, which the
+        -- write handler mistook for EWOULDBLOCK and kept retrying forever,
+        -- spinning the ioloop on EPOLLOUT. Without the fix this test times
+        -- out instead of completing.
+        it("IOStream:write_zero_copy, empty buffer completes", function()
+            local io = turbo.ioloop.instance()
+            local port = math.random(10000,40000)
+            local connected, failed = false, false
+            local completed = false
+
+            -- Server
+            local Server = class("TestServer", turbo.tcpserver.TCPServer)
+            function Server:handle_stream(stream)
+                io:add_callback(function()
+                    local empty = turbo.structs.buffer()
+                    stream:write_zero_copy(empty, function()
+                        completed = true
+                        stream:close()
+                    end)
+                end)
+            end
+            local srv = Server(io)
+            srv:listen(port)
+
+            io:add_callback(function()
+                -- Client
+                local fd = turbo.socket.new_nonblock_socket(turbo.socket.AF_INET,
+                    turbo.socket.SOCK_STREAM,
+                    0)
+                local stream = turbo.iostream.IOStream(fd, io)
+                assert.equal(stream:connect("127.0.0.1",
+                    port,
+                    turbo.socket.AF_INET,
+                    function()
+                        connected = true
+                        coroutine.yield (turbo.async.task(
+                            stream.read_until_close, stream))
+                        io:close()
+                    end,
+                    function(err)
+                        failed = true
+                        io:close()
+                        error("Could not connect.")
+                    end), 0)
+            end)
+
+            io:wait(5)
+            srv:stop()
+            assert.falsy(failed)
+            assert.truthy(connected)
+            assert.truthy(completed)
+        end)
+
+        -- Regression: the same bug as above also existed in the ordinary
+        -- buffered write path (write(), not write_zero_copy()). write("")
+        -- with nothing else pending left _write_buffer_size at 0, send()
+        -- returned 0, and the write handler's callback never fired.
+        it("IOStream:write, empty string still fires the callback", function()
+            local io = turbo.ioloop.instance()
+            local port = math.random(10000,40000)
+            local connected, failed = false, false
+            local completed = false
+
+            -- Server
+            local Server = class("TestServer", turbo.tcpserver.TCPServer)
+            function Server:handle_stream(stream)
+                io:add_callback(function()
+                    stream:write("", function()
+                        completed = true
+                        stream:close()
+                    end)
+                end)
+            end
+            local srv = Server(io)
+            srv:listen(port)
+
+            io:add_callback(function()
+                -- Client
+                local fd = turbo.socket.new_nonblock_socket(turbo.socket.AF_INET,
+                    turbo.socket.SOCK_STREAM,
+                    0)
+                local stream = turbo.iostream.IOStream(fd, io)
+                assert.equal(stream:connect("127.0.0.1",
+                    port,
+                    turbo.socket.AF_INET,
+                    function()
+                        connected = true
+                        coroutine.yield (turbo.async.task(
+                            stream.read_until_close, stream))
+                        io:close()
+                    end,
+                    function(err)
+                        failed = true
+                        io:close()
+                        error("Could not connect.")
+                    end), 0)
+            end)
+
+            io:wait(5)
+            srv:stop()
+            assert.falsy(failed)
+            assert.truthy(connected)
+            assert.truthy(completed)
+        end)
+
     end)
 end)

--- a/spec/websocket_spec.lua
+++ b/spec/websocket_spec.lua
@@ -1,0 +1,79 @@
+--- Turbo.lua Unit test
+--
+-- Copyright 2026 John Abrahamsen
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+-- http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+_G.__TURBO_USE_LUASOCKET__ = os.getenv("TURBO_USE_LUASOCKET") and true or false
+_G.TURBO_SSL = true
+
+local turbo = require "turbo"
+
+describe("turbo.websocket Namespace", function()
+
+    local function make_handler(url_args)
+        local stream = {
+            set_close_callback = function() end,
+            read_bytes = function() end,
+        }
+        local opened_with
+        local handler = setmetatable({
+            stream = stream,
+            _url_args = url_args,
+            open = function(self, ...)
+                opened_with = {...}
+            end,
+        }, { __index = turbo.websocket.WebSocketHandler })
+        return handler, function() return opened_with end
+    end
+
+    -- Regression: route captures (e.g. {"^/ws/(%d+)$", MyHandler}) were
+    -- stored in self._url_args by RequestHandler.initialize like every
+    -- other handler, but _continue_ws called self:open() with no
+    -- arguments, so WebSocketHandler:open() never received them.
+    it("WebSocketHandler:open should receive the URL capture arguments",
+        function()
+        local handler, opened_with = make_handler({"42", "extra"})
+
+        handler:_continue_ws()
+
+        assert.same({"42", "extra"}, opened_with())
+    end)
+
+    -- web.Application:_get_request_handlers does {path:match(pattern)},
+    -- and Lua's string.match returns the whole match when the pattern has
+    -- no captures, so a capture-less route never actually produces an
+    -- empty _url_args through real dispatch, it's {path}.
+    it("WebSocketHandler:open should receive the whole match for a \
+        capture-less route", function()
+        local handler, opened_with = make_handler({"/ws"})
+
+        handler:_continue_ws()
+
+        assert.same({"/ws"}, opened_with())
+    end)
+
+    -- Defensive: _url_args is nil for any WebSocketHandler not constructed
+    -- via normal Application dispatch (e.g. a hand-built instance). Must
+    -- not throw "bad argument #1 to 'unpack' (table expected, got nil)".
+    it("WebSocketHandler:open should not error when _url_args is nil",
+        function()
+        local handler, opened_with = make_handler(nil)
+
+        assert.has_no.errors(function()
+            handler:_continue_ws()
+        end)
+        assert.same({}, opened_with())
+    end)
+
+end)

--- a/turbo/iostream.lua
+++ b/turbo/iostream.lua
@@ -874,6 +874,22 @@ end
 if platform.__LINUX__ and not _G.__TURBO_USE_LUASOCKET__ then
     function iostream.IOStream:_handle_write_nonconst()
         local errno, fd
+        if self._write_buffer_size == 0 then
+            -- Nothing to send, e.g. write("", callback). send() of a
+            -- zero-length buffer legitimately returns 0, indistinguishable
+            -- from EWOULDBLOCK below, so complete immediately instead of
+            -- calling send() at all, otherwise the callback never fires.
+            self._write_buffer:clear()
+            self._write_buffer_offset = 0
+            if self._write_callback then
+                local callback = self._write_callback
+                local arg = self._write_callback_arg
+                self._write_callback = nil
+                self._write_callback_arg = nil
+                self:_run_callback(callback, arg)
+            end
+            return
+        end
         local ptr, sz = self._write_buffer:get()
         local buf = ptr + self._write_buffer_offset
         local num_bytes = tonumber(C.send(
@@ -924,6 +940,23 @@ if platform.__LINUX__ and not _G.__TURBO_USE_LUASOCKET__ then
         local errno, fd
         -- The reference is removed once the write is complete.
         local buf, sz = self._const_write_buffer:get()
+        if sz == 0 then
+            -- send() of a zero-length buffer legitimately returns 0, which
+            -- is indistinguishable from EWOULDBLOCK below. Complete an empty
+            -- buffer immediately instead of calling send() at all, otherwise
+            -- the write never finishes and the ioloop spins on EPOLLOUT
+            -- forever (e.g. serving a zero-length static file).
+            self._write_buffer_offset = 0
+            self._const_write_buffer = nil
+            if self._write_callback then
+                local callback = self._write_callback
+                local arg = self._write_callback_arg
+                self._write_callback = nil
+                self._write_callback_arg = nil
+                self:_run_callback(callback, arg)
+            end
+            return
+        end
         local ptr = buf + self._write_buffer_offset
         local _sz = sz - self._write_buffer_offset
         local num_bytes = C.send(
@@ -1350,6 +1383,24 @@ if _G.TURBO_SSL and platform.__LINUX__  and not _G.__TURBO_USE_LUASOCKET__ then
             return nil
         end
 
+        if self._write_buffer_size == 0 then
+            -- Nothing to send, e.g. write("", callback). SSL_write() of a
+            -- zero-length buffer legitimately returns 0, indistinguishable
+            -- from EAGAIN/WANT_WRITE below, so complete immediately instead
+            -- of calling SSL_write() at all, otherwise the callback never
+            -- fires.
+            self._write_buffer:clear()
+            self._write_buffer_offset = 0
+            if self._write_callback then
+                local callback = self._write_callback
+                local arg = self._write_callback_arg
+                self._write_callback = nil
+                self._write_callback_arg = nil
+                self:_run_callback(callback, arg)
+            end
+            return
+        end
+
         local ptr = self._write_buffer:get()
         ptr = ptr + self._write_buffer_offset
         local n = crypto.SSL_write(self._ssl, ptr, self._write_buffer_size)
@@ -1407,6 +1458,24 @@ if _G.TURBO_SSL and platform.__LINUX__  and not _G.__TURBO_USE_LUASOCKET__ then
         end
 
         local buf, sz = self._const_write_buffer:get()
+        if sz == 0 then
+            -- SSL_write() of a zero-length buffer legitimately returns 0,
+            -- which is indistinguishable from EAGAIN/WANT_WRITE below.
+            -- Complete an empty buffer immediately instead of calling
+            -- SSL_write() at all, otherwise the write never finishes and
+            -- the ioloop spins on EPOLLOUT forever (e.g. serving a
+            -- zero-length static file).
+            self._write_buffer_offset = 0
+            self._const_write_buffer = nil
+            if self._write_callback then
+                local callback = self._write_callback
+                local arg = self._write_callback_arg
+                self._write_callback = nil
+                self._write_callback_arg = nil
+                self:_run_callback(callback, arg)
+            end
+            return
+        end
         buf = buf + self._write_buffer_offset
         sz = sz - self._write_buffer_offset
         local n = crypto.SSL_write(self._ssl, buf, sz)

--- a/turbo/websocket.lua
+++ b/turbo/websocket.lua
@@ -266,7 +266,33 @@ if le then
         end
     end
 elseif be then
-    -- FIXME: Create funcs for BE.
+    -- Network byte order is big-endian, so on a BE host the wire bytes are
+    -- already in host order, no conversion needed.
+    local _tmp_convert_16 = ffi.new("uint16_t[1]")
+    function websocket.WebSocketStream:_frame_len_16(data)
+        ffi.copy(_tmp_convert_16, data, 2)
+        self._payload_len = tonumber(_tmp_convert_16[0])
+        if self._mask_bit then
+            self.stream:read_bytes(4, self._frame_mask_key, self)
+        else
+            self.stream:read_bytes(self._payload_len,
+                                   self._frame_payload,
+                                   self)
+        end
+    end
+
+    local _tmp_convert_64 = ffi.new("uint64_t[1]")
+    function websocket.WebSocketStream:_frame_len_64(data)
+        ffi.copy(_tmp_convert_64, data, 8)
+        self._payload_len = tonumber(_tmp_convert_64[0])
+        if self._mask_bit then
+            self.stream:read_bytes(4, self._frame_mask_key, self)
+        else
+            self.stream:read_bytes(self._payload_len,
+                                   self._frame_payload,
+                                   self)
+        end
+    end
 end
 
 function websocket.WebSocketStream:_frame_mask_key(data)
@@ -329,7 +355,52 @@ if le then
         self.stream:write(data, callback, callback_arg)
     end
 elseif be then
-    -- TODO: create websocket.WebSocketStream:_send_frame for BE.
+    -- Network byte order is big-endian, so on a BE host the length fields
+    -- are already in wire order, no byte swap needed on send either.
+    function websocket.WebSocketStream:_send_frame(finflag, opcode, data,
+        callback, callback_arg)
+        if self.stream:closed() then
+            return
+        end
+
+        local data_sz = data:len()
+        _ws_header.flags = bit.bor(finflag and 0x80 or 0x0, opcode)
+
+        -- 7 bit.
+        if data_sz < 0x7e then
+            _ws_header.len = bit.bor(data_sz,
+                                     self.mask_outgoing and 0x80 or 0x0)
+            self.stream:write(ffi.string(_ws_header, 2))
+
+        -- 16 bit
+        elseif data_sz <= 0xffff then
+            _ws_header.len = bit.bor(126, self.mask_outgoing and 0x80 or 0x0)
+            _ws_header.ext_len.sh = data_sz
+            self.stream:write(ffi.string(_ws_header, 4))
+
+        -- 64 bit
+        else
+            _ws_header.len = bit.bor(127, self.mask_outgoing and 0x80 or 0x0)
+            _ws_header.ext_len.ll = data_sz
+            self.stream:write(ffi.string(_ws_header, 10))
+        end
+
+        if self.mask_outgoing == true then
+            -- Create a random mask from OS entropy.
+            local ws_mask = ffi.new("unsigned char[4]")
+            local rnd = util.secure_random_bytes(4)
+            ws_mask[0] = rnd:byte(1)
+            ws_mask[1] = rnd:byte(2)
+            ws_mask[2] = rnd:byte(3)
+            ws_mask[3] = rnd:byte(4)
+            self.stream:write(ffi.string(ws_mask, 4))
+            self.stream:write(_unmask_payload(ws_mask, data), callback, callback_arg)
+            return
+        end
+
+        -- Do not return until write is flushed to iostream :).
+        self.stream:write(data, callback, callback_arg)
+    end
 end
 
 
@@ -486,7 +557,7 @@ function websocket.WebSocketHandler:_continue_ws()
     self.stream:set_close_callback(self._socket_closed, self)
     self._fragmented_message_buffer = buffer(1024)
     self.stream:read_bytes(2, self._accept_frame, self)
-    self:open()
+    self:open(unpack(self._url_args or {}))
 end
 
 function websocket.WebSocketHandler:_frame_payload(data)


### PR DESCRIPTION
## Summary

- Zero-length writes (e.g. a 0-byte static file, or `write("")`) used to never complete: `send()`/`SSL_write()` legitimately return 0 for an empty buffer, and the write handlers treated any 0 return as "would block, retry" instead of checking completion first. For `write_zero_copy()` this spun the ioloop at ~100% CPU forever. Fixed in all four write handlers in `iostream.lua`.
- `WebSocketHandler:open()` never received URL route captures, even though every other handler gets them via `self._url_args`. Fixed, with a nil guard for handlers not built through normal `Application` dispatch.
- WebSocket big-endian support (`_frame_len_16`, `_frame_len_64`, `_send_frame`) was a set of empty stubs, a hard crash on ppc/s390x hosts rather than just a byte-order bug. Implemented (wire order already equals host order on BE, so no byte-swap needed). Not tested on real BE hardware, verified by code reading against RFC 6455 only.
- All rockspecs pointed at `git://github.com/...`, which GitHub disabled in 2022, breaking `luarocks install turbo` entirely. Fixed for the non-frozen rockspecs (`turbo-2.1-4`, `turbo-dev-1`).
- Added `spec/websocket_spec.lua` and a couple of regression tests to `spec/iostream_spec.lua`, and wired the websocket spec into the default CI run.

Closes #332, #328, #268, #340

## Test plan

- [x] `make docker-test` (default suite): 72/0
- [x] `make docker-test ARGS="spec/iostream_spec.lua"`: new tests pass, confirmed they fail with `Sync wait operation timed out` against the pre-fix code
- [x] `make docker-test ARGS="spec/websocket_spec.lua"`: 3/3
- [x] Live check in Docker: curled a real 0-byte file through `StaticFileHandler`, 200 response in ~3ms, CPU idle afterward